### PR TITLE
[TL-27] Filter asset types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,21 +163,21 @@ workflows:
           context: api-assume-role-housing-development-context
           requires:
             - build-and-test
-#          filters:
-#           branches:
-#            only: master
+          filters:
+           branches:
+            only: master
       - terraform-init-and-apply-to-development:
           requires:
             - assume-role-development
-#          filters:
-#           branches:
-#            only: master
+          filters:
+           branches:
+            only: master
       - deploy-to-development:
           requires:
             - terraform-init-and-apply-to-development
-#          filters:
-#           branches:
-#            only: master
+          filters:
+           branches:
+            only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,21 +163,21 @@ workflows:
           context: api-assume-role-housing-development-context
           requires:
             - build-and-test
-          filters:
-           branches:
-            only: master
+#          filters:
+#           branches:
+#            only: master
       - terraform-init-and-apply-to-development:
           requires:
             - assume-role-development
-          filters:
-           branches:
-            only: master
+#          filters:
+#           branches:
+#            only: master
       - deploy-to-development:
           requires:
             - terraform-init-and-apply-to-development
-          filters:
-           branches:
-            only: master
+#          filters:
+#           branches:
+#            only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -56,6 +56,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 {
                     var asset = fixture.Create<QueryableAsset>();
                     asset.AssetAddress.Uprn = value;
+                    asset.AssetType = value;
 
                     listOfAssets.Add(asset);
                 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -35,6 +36,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
+        public async Task WhenAssetTypesAreProvided(IEnumerable<string> assetTypes)
+        {
+            var assetTypesString = string.Join(',', assetTypes);
+            var route = new Uri($"api/v1/search/assets?searchText={AssetFixture.Alphabet.Last()}&assetTypes={assetTypesString}&pageSize={5}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
 
         public void ThenTheLastRequestShouldBeBadRequestResult()
         {
@@ -52,6 +61,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             var result = JsonSerializer.Deserialize<APIResponse<GetAssetListResponse>>(resultBody, _jsonOptions);
 
             result.Results.Assets.Count.Should().Be(pageSize);
+        }
+
+        public async Task ThenOnlyTheseAssetTypesShouldBeIncluded(IEnumerable<string> allowedAssetTypes)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIResponse<GetAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Should().OnlyContain(a => allowedAssetTypes.Contains(a.AssetType));
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps;
 using TestStack.BDDfy;
@@ -50,6 +51,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenAPageSizeIsProvided(5))
                 .Then(t => _steps.ThenTheReturningResultsShouldBeOfThatSize(5))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceFiltersGivenAssetTypes()
+        {
+            var assetTypes = AssetFixture.Alphabet.TakeLast(2);
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenAssetTypesAreProvided(assetTypes))
+                .Then(t => _steps.ThenOnlyTheseAssetTypesShouldBeIncluded(assetTypes))
                 .BDDfy();
         }
     }

--- a/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
@@ -9,6 +9,9 @@ namespace HousingSearchApi.V1.Boundary.Requests
         [FromQuery(Name = "searchText")]
         public string SearchText { get; set; }
 
+        [FromQuery(Name = "assetTypes")]
+        public string AssetTypes { get; set; }
+
         [FromQuery(Name = "pageSize")]
         public int PageSize { get; set; } = DefaultPageSize;
 

--- a/HousingSearchApi/V1/Interfaces/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Interfaces/AssetQueryGenerator.cs
@@ -19,35 +19,28 @@ namespace HousingSearchApi.V1.Interfaces
 
         public QueryContainer Create(HousingSearchRequest request, QueryContainerDescriptor<QueryableAsset> q)
         {
-            if (!(request is HousingSearchRequest housingSearchRequest)) return null;
-
-            var queryContainer = new QueryContainer();
             var filters = new List<Func<QueryContainerDescriptor<QueryableAsset>, QueryContainer>>();
+            var listOfWildCardedWords = _wildCardAppenderAndPrepender.Process(request.SearchText);
 
-            var listOfWildCardedWords = _wildCardAppenderAndPrepender.Process(housingSearchRequest.SearchText);
-
-            Func<QueryContainerDescriptor<QueryableAsset>, QueryContainer> filterBySearchTextContainer =
-                (containerDescriptor) => containerDescriptor.QueryString(q => q.Query($"({string.Join(" AND ", listOfWildCardedWords)}) " + string.Join(' ', listOfWildCardedWords))
+            #region Filter definitions
+            QueryContainer FilterBySearchTextContainer(QueryContainerDescriptor<QueryableAsset> containerDescriptor) =>
+                containerDescriptor
+                    .QueryString(qs => qs.Query($"({string.Join(" AND ", listOfWildCardedWords)}) " + string.Join(' ', listOfWildCardedWords))
                     .Fields(f => f.Field("*"))
                     .Type(TextQueryType.MostFields));
 
-            filters.Add(filterBySearchTextContainer);
+            QueryContainer FilterByTypeContainer(QueryContainerDescriptor<QueryableAsset> containerDescriptor) =>
+                containerDescriptor
+                    .QueryString(qs => qs.Query(string.Join(' ', request.AssetTypes.Split(",")))
+                    .Fields(f => f.Field(asset => asset.AssetType))
+                    .Type(TextQueryType.MostFields));
+            #endregion
 
-            if (!string.IsNullOrWhiteSpace(housingSearchRequest.AssetTypes))
-            {
-                var types = housingSearchRequest.AssetTypes.Split(",");
+            filters.Add(FilterBySearchTextContainer);
+            if (!string.IsNullOrWhiteSpace(request.AssetTypes))
+                filters.Add(FilterByTypeContainer);
 
-                Func<QueryContainerDescriptor<QueryableAsset>, QueryContainer> filterByTypeContainer =
-                    (containerDescriptor) => containerDescriptor.QueryString(q => q.Query(string.Join(' ', types))
-                        .Fields(f => f.Field(asset => asset.AssetType))
-                        .Type(TextQueryType.MostFields));
-
-                filters.Add(filterByTypeContainer);
-            }
-
-            queryContainer = q.Bool(bq => bq.Filter(filters.ToArray()));
-
-            return queryContainer;
+            return q.Bool(bq => bq.Filter(filters.ToArray()));
         }
     }
 }


### PR DESCRIPTION
## Adds filtering on `AssetType` for housing search queries

`AssetType` is filtered from a comma-separated list provided to the `HousingSearchRequest` in the URL query params.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Currently I assign for `AssetType` in `AssetFixture` the same value as is used for  `AssetAddress.Uprn`. 
Might be good for this to be more random.
