### PR TITLE
Search by target id in account

### DIFF
--- a/HousingSearchApi/V1/Boundary/Requests/GetAccountListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAccountListRequest.cs
@@ -1,7 +1,9 @@
+using System;
+
 namespace HousingSearchApi.V1.Boundary.Requests
 {
     public class GetAccountListRequest : HousingSearchRequest
     {
-
+        public Guid TargetId { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
@@ -7,10 +7,6 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
     {
         public GetAccountListRequestValidator()
         {
-            /*RuleFor(x => x.SearchText).NotNull()
-                                      .NotEmpty()
-                                      .MinimumLength(2)
-                                      .NotXssString();*/
             RuleFor(x => x.PageSize).GreaterThan(0);
             RuleFor(x => x.SortBy).NotXssString();
         }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
@@ -7,6 +7,35 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
     {
         public GetAccountListRequestValidator()
         {
+            RuleFor(x => x.SearchText).NotNull()
+                .DependentRules(() =>
+                {
+                    RuleFor(x => x.TargetId).Null();
+                    RuleFor(x => x.TargetId).Empty();
+                })
+                .NotEmpty()
+                .DependentRules(() =>
+                {
+                    RuleFor(x => x.TargetId).Null();
+                    RuleFor(x => x.TargetId).Empty();
+                })
+                .MaximumLength(2)
+                .NotXssString();
+
+            RuleFor(x => x.TargetId).NotNull()
+                .DependentRules(() =>
+                {
+                    RuleFor(x => x.SearchText).Null();
+                    RuleFor(x => x.SearchText).Empty();
+                })
+                .NotEmpty()
+                .DependentRules(() =>
+                {
+                    RuleFor(x => x.SearchText).Null();
+                    RuleFor(x => x.SearchText).Empty();
+                })
+                .NotXssString();
+
             RuleFor(x => x.PageSize).GreaterThan(0);
             RuleFor(x => x.SortBy).NotXssString();
         }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAccountListRequestValidator.cs
@@ -7,10 +7,10 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
     {
         public GetAccountListRequestValidator()
         {
-            RuleFor(x => x.SearchText).NotNull()
+            /*RuleFor(x => x.SearchText).NotNull()
                                       .NotEmpty()
                                       .MinimumLength(2)
-                                      .NotXssString();
+                                      .NotXssString();*/
             RuleFor(x => x.PageSize).GreaterThan(0);
             RuleFor(x => x.SortBy).NotXssString();
         }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
@@ -33,7 +33,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         new List<string> { "paymentReference", "tenure.fullAddress", "tenure.primaryTenants.fullName" })
                     .WithExactQuery(accountListRequest.SearchText,
                         new List<string> { "paymentReference", "tenure.fullAddress", "tenure.primaryTenants.fullName" });
-            if(accountListRequest.TargetId!=Guid.Empty)
+            if (accountListRequest.TargetId != Guid.Empty)
                 _queryBuilder
                     .WithWildstarQuery(accountListRequest.TargetId.ToString(),
                         new List<string> { "targetId" })

--- a/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
@@ -25,7 +25,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
             if (accountListRequest.TargetId == Guid.Empty && accountListRequest.SearchText.Trim().Length == 0)
-                throw new Exception("Input string is not a correct format.");
+                throw new Exception("Input search string shouldn't be empty.");
 
             if (!string.IsNullOrEmpty(accountListRequest.SearchText))
                 _queryBuilder

--- a/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
@@ -24,6 +24,8 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (accountListRequest == null)
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
+            if (accountListRequest.TargetId == Guid.Empty && accountListRequest.SearchText.Trim().Length == 0)
+                throw new Exception("Input string is not a correct format.");
 
             if (!string.IsNullOrEmpty(accountListRequest.SearchText))
                 _queryBuilder
@@ -31,6 +33,12 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         new List<string> { "paymentReference", "tenure.fullAddress", "tenure.primaryTenants.fullName" })
                     .WithExactQuery(accountListRequest.SearchText,
                         new List<string> { "paymentReference", "tenure.fullAddress", "tenure.primaryTenants.fullName" });
+            if(accountListRequest.TargetId!=Guid.Empty)
+                _queryBuilder
+                    .WithWildstarQuery(accountListRequest.TargetId.ToString(),
+                        new List<string> { "targetId" })
+                    .WithExactQuery(accountListRequest.TargetId.ToString(),
+                        new List<string> { "targetId" });
 
             return _queryBuilder.Build(q);
         }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AccountQueryGenerator.cs
@@ -24,9 +24,6 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (accountListRequest == null)
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
-            if (accountListRequest.TargetId == Guid.Empty && accountListRequest.SearchText.Trim().Length == 0)
-                throw new Exception("Input search string shouldn't be empty.");
-
             if (!string.IsNullOrEmpty(accountListRequest.SearchText))
                 _queryBuilder
                     .WithWildstarQuery(accountListRequest.SearchText,

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -21,7 +21,7 @@ terraform {
 
 data "aws_vpc" "development_vpc" {
   tags = {
-    Name = "vpc-housing-development"
+    Name = "housing-dev"
   }
 }
 


### PR DESCRIPTION
## Link to JIRA ticket

[https://app.clickup.com/t/1kcgrhd](https://app.clickup.com/t/1kcgrhd)
## Describe this PR

According to the previous PR about creating the generic housing search request, in this PR we can use account search request to search by target id only.
 
#### _Checklist_

- [x] Search based on the target id added to the /search/account entity 