### PR TITLE
Child asset get

### DIFF
--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -78,7 +78,7 @@ namespace HousingSearchApi.V1.Gateways
 
             if (searchResponse == null) return assetListResponse;
             assetListResponse.Assets.AddRange(searchResponse.Documents.Select(queryableAsset =>
-                queryableAsset.Create())
+                queryableAsset.CreateAll())
             );
 
             assetListResponse.SetTotal(searchResponse.Total);

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -29,6 +29,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                 .WithExactQuery(assetListRequest.SearchText,
                     new List<string>
                     {
+                        "parentAssetIds",
                         "assetAddress.addressLine1",
                         "assetAddress.uprn",
                         "assetAddress.postCode"

--- a/HousingSearchApi/V1/Infrastructure/IndexSelector.cs
+++ b/HousingSearchApi/V1/Infrastructure/IndexSelector.cs
@@ -25,7 +25,7 @@ namespace HousingSearchApi.V1.Infrastructure
                 return Indices.Index(new List<IndexName> { "tenures" });
 
             if (type == typeof(QueryableAsset))
-                return Indices.Index(new List<IndexName> { "assets" });
+                return Indices.Index(new List<IndexName> { "assetsnew" });
 
             if (type == typeof(QueryableAccount))
                 return Indices.Index(new List<IndexName> { "accounts" });


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/HFS-220

## Describe this PR

### *What is the problem we're trying to solve*

From Elastic Search Asset Search endpoint there was no way to retrieve the child assets. 

### *What changes have we introduced*

Added new filter field parentAssetIds which is used to get all the child assets from the newly indexed Assets

Include any links to commits that introduce significant additions of code if they help explain the process of coming to the solution. e.g Addition of test database setup, addition of first test and production class, removal of buggy code, etc.

#### _Checklist_

- [true ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [true  ] Added tests to cover all new production code
- [true  ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [true  ] Checked all code for possible refactoring
- [true  ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
