### PR TITLE
Updated addressLine 1 type to text

### DIFF
--- a/HousingSearchApi/data/elasticsearch/assetIndex.json
+++ b/HousingSearchApi/data/elasticsearch/assetIndex.json
@@ -53,7 +53,7 @@
             }
           },
           "addressLine1": {
-            "type": "keyword",
+            "type": "text",
             "normalizer": "my_normalizer",
             "fields": {
               "keyword": {


### PR DESCRIPTION
## Link to JIRA ticket

[Jira Ticket](https://hackney.atlassian.net/browse/MTTL-2671)

## Describe this PR

AddressLine1 field has type keyword which doesn’t support partial match, so most relevant results aren’t displayed at top.

To solve this the field type has been changed to text.