### PR TITLE
Mttl 3166 - Filter Housing Officers from Person Search results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,34 +244,25 @@ workflows:
           context: api-assume-role-housing-development-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: master
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
-          filters:
-            branches:
-              only: master
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
-          filters:
-            branches:
-              only: master
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,16 +253,16 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting:

--- a/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
+++ b/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.72.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.34.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0-feat-mttl-3166-0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
+++ b/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.72.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.37.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
+++ b/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.72.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0-feat-mttl-3166-0001" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
@@ -159,5 +159,26 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             Thread.Sleep(5000);
         }
+
+        public void GivenThereExistPersonsWithDifferentPersonTypes(string firstName, string lastName, List<PersonType> personTypes)
+        {
+            var listOfPersons = new List<QueryablePerson>();
+
+            foreach (var personType in personTypes)
+            {
+                listOfPersons.Add(new QueryablePerson
+                {
+                    Firstname = firstName,
+                    Surname = lastName,
+                    PersonTypes = new List<string> { personType.ToString() }
+                });
+            }
+
+            var awaitable = ElasticSearchClient.IndexManyAsync(listOfPersons, INDEX).ConfigureAwait(true);
+
+            while (!awaitable.GetAwaiter().IsCompleted) { }
+
+            Thread.Sleep(5000);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetPersonsSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetPersonsSteps.cs
@@ -171,9 +171,9 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIResponse<GetPersonListResponse>>(resultBody, _jsonOptions);
-            
+
             var allPersonTypes = new List<String>();
-            
+
             foreach (var personResult in result.Results.Persons)
             {
                 allPersonTypes.AddRange(personResult.PersonTypes);

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetPersonsSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetPersonsSteps.cs
@@ -166,5 +166,20 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
                 }
             }
         }
+
+        public async Task ThenTheResultShouldNotContainHousingOfficers()
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIResponse<GetPersonListResponse>>(resultBody, _jsonOptions);
+            
+            var allPersonTypes = new List<String>();
+            
+            foreach (var personResult in result.Results.Persons)
+            {
+                allPersonTypes.AddRange(personResult.PersonTypes);
+            }
+
+            allPersonTypes.Should().NotContain(PersonType.HousingOfficer.ToString());
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetPersonsStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetPersonsStories.cs
@@ -101,7 +101,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
         public void ServiceDoesNotReturnHousingOfficers(string firstName, string lastName)
         {
             this.Given(g => _personsFixture.GivenAPersonIndexExists())
-                .Given(g => _personsFixture.GivenThereExistPersonsWithDifferentPersonTypes(firstName, lastName, new List<PersonType> { PersonType.HousingOfficer,  PersonType.Tenant, PersonType.Leaseholder, PersonType.HousingOfficer}))
+                .Given(g => _personsFixture.GivenThereExistPersonsWithDifferentPersonTypes(firstName, lastName, new List<PersonType> { PersonType.HousingOfficer, PersonType.Tenant, PersonType.Leaseholder, PersonType.HousingOfficer }))
                 .When(w => _steps.WhenSearchingByFirstAndLastName(firstName, lastName))
                 .Then(t => _steps.ThenTheResultShouldNotContainHousingOfficers())
                 .BDDfy();

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetPersonsStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetPersonsStories.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Hackney.Shared.HousingSearch.Domain;
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps;
 using TestStack.BDDfy;
@@ -92,6 +93,17 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Given(g => _personsFixture.GivenDifferentTypesOfTenureTypes("SomePersonName", "SomePersonLastName", new List<string> { "Tenant", "Leaseholder" }))
                 .When(w => _steps.WhenARequestContainsSearchByTenureTypes("SomePersonLastName", new List<string> { "Tenant" }))
                 .Then(t => _steps.ThenTheResultShouldContainOnlyTheSearchedTypes(new List<string> { "Tenant" }))
+                .BDDfy();
+        }
+
+        [Theory]
+        [InlineData("SomePersonName", "SomePersonLastName")]
+        public void ServiceDoesNotReturnHousingOfficers(string firstName, string lastName)
+        {
+            this.Given(g => _personsFixture.GivenAPersonIndexExists())
+                .Given(g => _personsFixture.GivenThereExistPersonsWithDifferentPersonTypes(firstName, lastName, new List<PersonType> { PersonType.HousingOfficer,  PersonType.Tenant, PersonType.Leaseholder, PersonType.HousingOfficer}))
+                .When(w => _steps.WhenSearchingByFirstAndLastName(firstName, lastName))
+                .Then(t => _steps.ThenTheResultShouldNotContainHousingOfficers())
                 .BDDfy();
         }
     }

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0-feat-mttl-3166-0001" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.34.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0-feat-mttl-3166-0001" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.35.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.37.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/HousingSearchApi/V1/Infrastructure/Factories/PersonQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/PersonQueryGenerator.cs
@@ -1,4 +1,5 @@
 using Hackney.Core.ElasticSearch.Interfaces;
+using Hackney.Shared.HousingSearch.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Persons;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Interfaces.Factories;
@@ -29,7 +30,8 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                 .WithWildstarQuery(personListRequest.SearchText,
                     new List<string> { "firstname", "surname" })
                 .WithExactQuery(personListRequest.SearchText,
-                    new List<string> { "firstname", "surname" }, new ExactSearchQuerystringProcessor());
+                    new List<string> { "firstname", "surname" }, new ExactSearchQuerystringProcessor())
+                .WithFilterQuery($"NOT {PersonType.HousingOfficer}", new List<string> { "personTypes" });
 
             if (personListRequest.PersonType.HasValue)
             {


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/MTTL-3166

## Describe this PR

### *What is the problem we're trying to solve*

Some staff data is returned in person search results, but it shouldn't. This PR adds filtering to hide Housing Officers from person search results.

### *What changes have we introduced*

- Filter out HOs from person search results
- Update pipeline to run terraform compliance from branches

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
