### PR TITLE
Add SimpleQuery type to housing search

### DIFF
--- a/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
+++ b/HousingSearchApi.Tests/HousingSearchApi.Tests.csproj
@@ -47,7 +47,7 @@
     </PackageReference>
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.73.0" />
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.40.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />

--- a/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
@@ -28,7 +28,7 @@ namespace HousingSearchApi.Tests.V1.Factories
         }
 
         [Fact]
-        public void GenratesCorrectQueryWhenUsingSimpleQuery()
+        public void GeneratesCorrectQueryWhenUsingSimpleQuery()
         {
             (Nest.QueryContainerDescriptor<QueryableAsset>, string, List<string>) paramsCalled = (null, "", null);
 

--- a/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
@@ -39,7 +39,7 @@ namespace HousingSearchApi.Tests.V1.Factories
             var request = new GetAssetListRequest
             {
                 SearchText = "12 Pitcairn",
-                SimpleQuery = true
+                IsSimpleQuery = true
             };
 
             var qcd = new Nest.QueryContainerDescriptor<QueryableAsset>();

--- a/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
@@ -1,0 +1,56 @@
+using Xunit;
+using AutoFixture;
+using FluentAssertions;
+using HousingSearchApi.V1.Infrastructure.Factories;
+using Moq;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using Hackney.Core.ElasticSearch.Interfaces;
+using HousingSearchApi.V1.Interfaces;
+using System.Collections.Generic;
+using HousingSearchApi.V1.Boundary.Requests;
+
+namespace HousingSearchApi.Tests.V1.Factories
+{
+    public class AssetQueryGeneratorTests
+    {
+        //private readonly Fixture _fixture = new Fixture();
+
+        private readonly AssetQueryGenerator _sut;
+        private readonly Mock<IQueryBuilder<QueryableAsset>> _queryBuilderMock;
+        private readonly Mock<IFilterQueryBuilder<QueryableAsset>> _queryFilterBuilder;
+
+        public AssetQueryGeneratorTests()
+        {
+            _queryBuilderMock = new Mock<IQueryBuilder<QueryableAsset>>();
+            _queryFilterBuilder = new Mock<IFilterQueryBuilder<QueryableAsset>>();
+
+            _sut = new AssetQueryGenerator(_queryBuilderMock.Object, _queryFilterBuilder.Object);
+        }
+
+        [Fact]
+        public void GenratesCorrectQueryWhenUsingSimpleQuery()
+        { 
+            (Nest.QueryContainerDescriptor<QueryableAsset>, string, List<string>) paramsCalled = (null, "", null);
+
+            // Arrange
+            _queryBuilderMock.Setup(x => x.BuildSimpleQuery(It.IsAny<Nest.QueryContainerDescriptor<QueryableAsset>>(), It.IsAny<string>(), It.IsAny<List<string>>()))
+                .Callback<Nest.QueryContainerDescriptor<QueryableAsset>, string, List<string>>((q, s, l) => paramsCalled = (q, s, l));
+
+            var request = new GetAssetListRequest
+            {
+                SearchText = "12 Pitcairn",
+                SimpleQuery = true
+            };
+
+            var qcd = new Nest.QueryContainerDescriptor<QueryableAsset>();
+
+            // Act
+            _ = _sut.Create<GetAssetListRequest>(request, qcd);
+
+            // Assert
+            Assert.Equal(request.SearchText, paramsCalled.Item2);
+            _queryBuilderMock.Verify(x => x.BuildSimpleQuery(It.IsAny<Nest.QueryContainerDescriptor<QueryableAsset>>(), It.IsAny<string>(), It.IsAny<List<string>>()), Times.Once);
+            
+        }
+    }
+}

--- a/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/AssetQueryGeneratorTests.cs
@@ -29,7 +29,7 @@ namespace HousingSearchApi.Tests.V1.Factories
 
         [Fact]
         public void GenratesCorrectQueryWhenUsingSimpleQuery()
-        { 
+        {
             (Nest.QueryContainerDescriptor<QueryableAsset>, string, List<string>) paramsCalled = (null, "", null);
 
             // Arrange
@@ -50,7 +50,6 @@ namespace HousingSearchApi.Tests.V1.Factories
             // Assert
             Assert.Equal(request.SearchText, paramsCalled.Item2);
             _queryBuilderMock.Verify(x => x.BuildSimpleQuery(It.IsAny<Nest.QueryContainerDescriptor<QueryableAsset>>(), It.IsAny<string>(), It.IsAny<List<string>>()), Times.Once);
-            
         }
     }
 }

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.2.0" />
-    <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.73.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.30.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
@@ -33,8 +33,8 @@ namespace HousingSearchApi.V1.Boundary.Requests
         [FromQuery(Name = "isDesc")]
         public bool IsDesc { get; set; }
 
-        [FromQuery(Name = "simplequery")]
-        public bool SimpleQuery { get; set; }
+        [FromQuery(Name = "issimplequery")]
+        public bool IsSimpleQuery { get; set; }
 
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/HousingSearchRequest.cs
@@ -33,8 +33,8 @@ namespace HousingSearchApi.V1.Boundary.Requests
         [FromQuery(Name = "isDesc")]
         public bool IsDesc { get; set; }
 
-        [FromQuery(Name = "matchType")]
-        public Nest.TextQueryType MatchType { get; set; } = Nest.TextQueryType.MostFields;
+        [FromQuery(Name = "simplequery")]
+        public bool SimpleQuery { get; set; }
 
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Core/FilterQueryBuilder.cs
+++ b/HousingSearchApi/V1/Infrastructure/Core/FilterQueryBuilder.cs
@@ -121,5 +121,18 @@ namespace HousingSearchApi.V1.Infrastructure.Core
 
             return queryContainer;
         }
+
+        public QueryContainer BuildSimpleQuery(QueryContainerDescriptor<T> containerDescriptor, string searchTerm, List<string> fields)
+        {
+            return containerDescriptor.SimpleQueryString(q => q.Fields(f =>
+            {
+                foreach (var field in fields)
+                {
+                    f = f.Field(field);
+                }
+                return f;
+            }
+            ).Query(searchTerm));
+        }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -28,13 +28,17 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (assetListRequest == null)
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
+            if (assetListRequest.SimpleQuery)
+            {
+                return _queryBuilder.BuildSimpleQuery(q, assetListRequest.SearchText, new List<string> { "assetAddress.addressLine1.textAddress", "assetAddress.postCode" });
+            }
+
             if (request.GetType() == typeof(GetAssetListRequest))
             {
                 //This is so assets search endpoint works as before
                 return _queryBuilder
                     .WithWildstarQuery(assetListRequest.SearchText,
-                        new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" },
-                         assetListRequest.MatchType)
+                        new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" })
                     .WithExactQuery(assetListRequest.SearchText,
                         new List<string>
                         {
@@ -65,8 +69,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.IsTemporaryAccomodation, new List<string> { "assetManagement.isTemporaryAccomodation" })
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
-                            new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" },
-                         assetListRequest.MatchType)
+                            new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" })
                         .WithExactQuery(assetListAllRequest.SearchText,
                             new List<string>
                             {

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -28,7 +28,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (assetListRequest == null)
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
-            if (assetListRequest.SimpleQuery)
+            if (assetListRequest.IsSimpleQuery)
             {
                 return _queryBuilder.BuildSimpleQuery(q, assetListRequest.SearchText, new List<string> { "assetAddress.addressLine1.textAddress", "assetAddress.postCode" });
             }


### PR DESCRIPTION
On advice of Matt Dendle, we have added the Simple Query type to use for address search. This will greatly improve the existing search by using a text mapped field sitting behind addressLine1 - for context it is worth watching this recorded session: https://drive.google.com/file/d/1orq7dARXtco3yXUJbs1Jsi0r9Rvb-yfj/view

Note that this is additional to existing Housing Search functionality and not replacing any existing functionality