### PR TITLE
targetid nullable and fluent validation

### DIFF
--- a/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetProcessListRequestValidatorTests.cs
+++ b/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetProcessListRequestValidatorTests.cs
@@ -1,0 +1,69 @@
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Requests.Validation;
+using System;
+using Xunit;
+using FluentValidation.TestHelper;
+
+namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
+{
+    public class GetProcessListRequestValidatorTests
+    {
+        private readonly GetProcessListRequestValidator _sut;
+
+        public GetProcessListRequestValidatorTests()
+        {
+            _sut = new GetProcessListRequestValidator();
+        }
+
+        [Fact]
+        public void ShouldNotErrorWithBothTargetIdAndTargetType()
+        {
+            var query = new GetProcessListRequest()
+            {
+                SearchText = "abc",
+                TargetId = Guid.NewGuid(),
+                TargetType = "tenure"
+            };
+            var result = _sut.TestValidate(query);
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void ShouldNotErrorWithOnlySearchText()
+        {
+            var query = new GetProcessListRequest()
+            {
+                SearchText = "abc",
+            };
+            var result = _sut.TestValidate(query);
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void ShouldNotErrorOnlyTargetIddSearchText()
+        {
+            var query = new GetProcessListRequest()
+            {
+                SearchText = "abc",
+                TargetId = Guid.NewGuid()
+            };
+            var result = _sut.TestValidate(query);
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public void ShouldErrorWithOnlyTargetType()
+        {
+            var query = new GetProcessListRequest()
+            {
+                SearchText = "abc",
+                TargetType = "tenure"
+            };
+            var result = _sut.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.TargetId);
+        }
+
+
+
+    }
+}

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetProcessesSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetProcessesSteps.cs
@@ -46,6 +46,13 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
 
+        public async Task WhenTargetTypeIsProvided(string targetType)
+        {
+            var route = new Uri($"api/v1/search/processes?searchText={ProcessFixture.Processes[2].TargetId}&targetType={targetType}&pageSize={5}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
 
         public async Task ThenTheReturningResultsShouldBeOfThatSize(int pageSize)
         {
@@ -63,5 +70,6 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             result.Results.Processes.All(x => x.TargetType == allowedTargetType && x.TargetId == allowedTargetId);
         }
+
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetProcessesStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetProcessesStories.cs
@@ -57,5 +57,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenOnlyTheseTargetTypeAndTargetIdShouldBeIncluded(targetType, targetId))
                 .BDDfy();
         }
+
+        [Fact]
+        public void ServiceFailWhenOnlyTargetTypeIsGiven()
+        {
+            var targetType = "tenure";
+            this.Given(g => _processesFixture.GivenAnProcessIndexExists())
+                .When(w => _steps.WhenTargetTypeIsProvided(targetType))
+                .Then(t => _steps.ThenTheLastRequestShouldBeBadRequestResult(default))
+                .BDDfy();
+        }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/GetProcessListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetProcessListRequest.cs
@@ -1,4 +1,3 @@
-using Hackney.Shared.Processes.Domain;
 using Microsoft.AspNetCore.Mvc;
 using System;
 
@@ -10,7 +9,7 @@ namespace HousingSearchApi.V1.Boundary.Requests
         public string TargetType { get; set; }
 
         [FromQuery(Name = "targetId")]
-        public Guid TargetId { get; set; }
+        public Guid? TargetId { get; set; }
 
         [FromQuery(Name = "isOpen")]
         public bool IsOpen { get; set; }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetProcessListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetProcessListRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using Hackney.Core.Validation;
+
+namespace HousingSearchApi.V1.Boundary.Requests.Validation
+{
+    public class GetProcessListRequestValidator : AbstractValidator<GetProcessListRequest>
+    {
+        public GetProcessListRequestValidator()
+        {
+            RuleFor(x => x.SearchText).NotNull()
+                                      .NotEmpty()
+                                      .MinimumLength(2)
+                                      .NotXssString();
+            RuleFor(x => x.PageSize).GreaterThan(0);
+            RuleFor(x => x.SortBy).NotXssString();
+            RuleFor(x => x.TargetId).NotNull().When(x => x.TargetType != null);
+        }
+    }
+}


### PR DESCRIPTION
For processes Search endpoint the target id should be nullable for worktray usecases. Also if targetType is provided then targetid should also be provided