### PR TITLE
Make staff patches into a list

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -2,16 +2,13 @@ using AutoFixture;
 using Elasticsearch.Net;
 using Hackney.Shared.HousingSearch.Domain.Process;
 using Hackney.Shared.HousingSearch.Factories;
-using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.Processes.Domain.Constants;
 using Nest;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using Process = Hackney.Shared.HousingSearch.Domain.Process.Process;
 
 namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/StaffFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/StaffFixture.cs
@@ -1,9 +1,9 @@
 using AutoFixture;
 using Elasticsearch.Net;
+using Hackney.Shared.HousingSearch.Domain.Staff;
 using Hackney.Shared.HousingSearch.Factories;
 using Hackney.Shared.HousingSearch.Gateways.Models.Staffs;
 using Nest;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,16 +16,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 {
     public class StaffFixture : BaseFixture
     {
-        //private static Fixture _fixture = new Fixture();
+        private static Fixture _fixture = new Fixture();
         private const string INDEX = "staff";
 
         public static Staff[] Staffs =
         {
-            Staff.Create("firstName1", "lastName1", "firstName1.lastName1@test.com", Guid.NewGuid(), Guid.NewGuid()),
-            Staff.Create("firstName2", "lastName2", "firstName2.lastName2@test.com", Guid.NewGuid(), Guid.NewGuid()),
-            Staff.Create("firstName3", "lastName3", "firstName3.lastName3@test.com", Guid.NewGuid(), Guid.NewGuid()),
-            Staff.Create("firstName4", "lastName4", "firstName4.lastName4@test.com", Guid.NewGuid(), Guid.NewGuid()),
-            Staff.Create("firstName5", "lastName5", "firstName5.lastName5@test.com", Guid.NewGuid(), Guid.NewGuid())
+            Staff.Create("firstName1", "lastName1", "firstName1.lastName1@test.com", new List<StaffPatch>{ _fixture.Create<StaffPatch>() }),
+            Staff.Create("firstName3", "lastName3", "firstName3.lastName3@test.com", new List<StaffPatch>{ _fixture.Create<StaffPatch>() }),
+            Staff.Create("firstName4", "lastName4", "firstName4.lastName4@test.com", new List<StaffPatch>{ _fixture.Create<StaffPatch>() }),
+            Staff.Create("firstName2", "lastName2", "firstName2.lastName2@test.com", new List<StaffPatch>{ _fixture.Create<StaffPatch>() }),
+            Staff.Create("firstName5", "lastName5", "firstName5.lastName5@test.com", new List<StaffPatch>{ _fixture.Create<StaffPatch>() })
         };
 
         public StaffFixture(IElasticClient elasticClient, HttpClient httpClient) : base(elasticClient, httpClient)

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.67.0-feat-list-staff-0004" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.67.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.62.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.67.0-feat-list-staff-0004" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetProcessListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetProcessListRequestValidator.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using Hackney.Core.Validation;
-using System;
 
 namespace HousingSearchApi.V1.Boundary.Requests.Validation
 {

--- a/HousingSearchApi/V1/Infrastructure/Factories/ProcessesQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/ProcessesQueryGenerator.cs
@@ -2,7 +2,6 @@ using Hackney.Core.ElasticSearch.Interfaces;
 using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.Processes.Domain.Constants;
 using HousingSearchApi.V1.Boundary.Requests;
-using HousingSearchApi.V1.Interfaces;
 using HousingSearchApi.V1.Interfaces.Factories;
 using Nest;
 using System;


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-3458

## Describe this PR

### *What is the problem we're trying to solve*

Sometimes staff can be assigned to multiple patches, which need to be returned from the api

### *What changes have we introduced*

Make a field called 'patches' that contains a list of patchAssignment details

### *Follow up actions after merging PR*

Update the ES index to have the correct mapping for staff patch assignment