### PR TITLE
UPRN search for tenured assets

### DIFF
--- a/HousingSearchApi/V1/Boundary/Requests/GetTenureListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetTenureListRequest.cs
@@ -1,7 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+
 namespace HousingSearchApi.V1.Boundary.Requests
 {
     public class GetTenureListRequest : HousingSearchRequest
     {
-
+        [FromQuery(Name = "uprn")]
+        public string Uprn { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetTenureListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetTenureListRequestValidator.cs
@@ -7,12 +7,15 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
     {
         public GetTenureListRequestValidator()
         {
-            RuleFor(x => x.SearchText).NotNull()
+            When(u => u.Uprn == null, () =>
+            {
+                RuleFor(x => x.SearchText).NotNull()
                                       .NotEmpty()
                                       .MinimumLength(2)
                                       .NotXssString();
-            RuleFor(x => x.PageSize).GreaterThan(0);
-            RuleFor(x => x.SortBy).NotXssString();
+                RuleFor(x => x.PageSize).GreaterThan(0);
+                RuleFor(x => x.SortBy).NotXssString();
+            });
         }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
@@ -22,16 +22,29 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (!(request is GetTenureListRequest tenureListRequest))
                 throw new ArgumentNullException($"{nameof(request).ToString()} shouldn't be null.");
 
-            if (string.IsNullOrWhiteSpace(tenureListRequest.SearchText)) return null;
+            if (tenureListRequest.SearchText != null && tenureListRequest.SearchText.Length > 0)
+            {
 
-            return _queryBuilder
+                return _queryBuilder
                 .WithWildstarQuery(tenureListRequest.SearchText, new List<string>
                 {
                     "paymentReference",
                     "tenuredAsset.fullAddress^3",
                     "householdMembers",
                     "householdMembers.fullName^3"
-                }).Build(q);
+                })
+                .Build(q);
+            }
+            else
+            {
+                return _queryBuilder
+                .WithExactQuery(tenureListRequest.Uprn,
+                new List<string>
+                {
+                    "tenuredAsset.uprn",
+                })
+                .Build(q);
+            }
         }
     }
 }


### PR DESCRIPTION
Exact UPRN search is needed on tenures to bring back all tenures related to an asset from the asset view page. ie booking history