### PR TITLE
Add Postcode Normalization when UseCustomSorting enabled

### DIFF
--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -11,6 +11,7 @@ using HousingSearchApi.V1.Boundary.Responses;
 using HousingSearchApi.V1.Boundary.Responses.Transactions;
 using HousingSearchApi.V1.Factories;
 using HousingSearchApi.V1.Gateways.Interfaces;
+using HousingSearchApi.V1.Helper;
 using HousingSearchApi.V1.Helper.Interfaces;
 using HousingSearchApi.V1.Interfaces;
 using System;
@@ -76,6 +77,12 @@ namespace HousingSearchApi.V1.Gateways
                 // and does filtering/sorting on that
                 // therefore pageSize (pagination) is redundant for this useCase
                 query.PageSize = CustomSortPageSize;
+
+                // if searchText contains a postCode, normalize the formatting
+                if (PostCodeHelpers.SearchTextIsValidPostCode(query.SearchText))
+                {
+                    query.SearchText = PostCodeHelpers.NormalizePostcode(query.SearchText);
+                }
             }
 
             var searchResponse = await _elasticSearchWrapper

--- a/HousingSearchApi/V1/Helper/PostCodeHelpers.cs
+++ b/HousingSearchApi/V1/Helper/PostCodeHelpers.cs
@@ -22,6 +22,8 @@ namespace HousingSearchApi.V1.Helper
 
         public static bool SearchTextIsValidPostCode(string searchText)
         {
+            if (searchText == null) return false;
+
             var trimmed = searchText.Replace(" ", "");
 
             if (trimmed.Length > 7) return false;

--- a/HousingSearchApi/V1/Helper/PostCodeHelpers.cs
+++ b/HousingSearchApi/V1/Helper/PostCodeHelpers.cs
@@ -1,0 +1,35 @@
+using System.Text.RegularExpressions;
+
+namespace HousingSearchApi.V1.Helper
+{
+    public static class PostCodeHelpers
+    {
+        public static string NormalizePostcode(string postcode)
+        {
+            //removes space in middle spaces
+            postcode = postcode.Replace(" ", "");
+
+            postcode = postcode.ToUpper();
+
+            return postcode.Length switch
+            {
+                5 => postcode.Insert(2, " "),
+                6 => postcode.Insert(3, " "),
+                7 => postcode.Insert(4, " "),
+                _ => postcode,
+            };
+        }
+
+        public static bool SearchTextIsValidPostCode(string searchText)
+        {
+            var trimmed = searchText.Replace(" ", "");
+
+            if (trimmed.Length > 7) return false;
+
+            const string pattern = @"^[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}$";
+            RegexOptions options = RegexOptions.IgnoreCase;
+
+            return Regex.Match(trimmed, pattern, options).Success;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of Changes

Property search in MMH doesn't work with postcodes that don't contain a space. I have copied the solution from RepairsAPI.