### PR TITLE
Fix UPRN query in housingSearch CustomSorting

### DIFF
--- a/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
@@ -8,6 +8,7 @@ using HousingSearchApi.V1.Helper;
 using Moq;
 using Nest;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -29,24 +30,24 @@ namespace HousingSearchApi.Tests.V1.Helper
         public void FilterResponse_WhenCalled_IncludesAddressesWithMatchingUPRN()
         {
             // Arrange
-            var asset = _fixture.Create<Asset>();
+            var assets = _fixture.CreateMany<Asset>().ToList();
 
             var content = new GetAssetListResponse
             {
-                Assets = new List<Asset> { asset }
+                Assets = assets
             };
 
             var searchModel = new GetAssetListRequest
             {
-                SearchText = asset.AssetId,
+                SearchText = assets.First().AssetId,
             };
 
             // Act
             _classUnderTest.FilterResponse(searchModel, content);
 
             // Assert
-
             content.Assets.Should().HaveCount(1);
+            content.Assets.First().AssetId.Should().Be(assets.First().AssetId);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
@@ -31,11 +31,13 @@ namespace HousingSearchApi.Tests.V1.Helper
             // Arrange
             var asset = _fixture.Create<Asset>();
 
-            var content = new GetAssetListResponse {
+            var content = new GetAssetListResponse
+            {
                 Assets = new List<Asset> { asset }
             };
 
-            var searchModel = new GetAssetListRequest {
+            var searchModel = new GetAssetListRequest
+            {
                 SearchText = asset.AssetId,
             };
 

--- a/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/CustomAddressSorterTests.cs
@@ -1,0 +1,50 @@
+using AutoFixture;
+using FluentAssertions;
+using Hackney.Shared.HousingSearch.Domain.Asset;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Responses;
+using HousingSearchApi.V1.Helper;
+using Moq;
+using Nest;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.Helper
+{
+    public class CustomAddressSorterTests
+    {
+        private readonly CustomAddressSorter _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        public CustomAddressSorterTests()
+        {
+            var comparer = new AddressComparer();
+
+            _classUnderTest = new CustomAddressSorter(comparer);
+        }
+
+        [Fact]
+        public void FilterResponse_WhenCalled_IncludesAddressesWithMatchingUPRN()
+        {
+            // Arrange
+            var asset = _fixture.Create<Asset>();
+
+            var content = new GetAssetListResponse {
+                Assets = new List<Asset> { asset }
+            };
+
+            var searchModel = new GetAssetListRequest {
+                SearchText = asset.AssetId,
+            };
+
+            // Act
+            _classUnderTest.FilterResponse(searchModel, content);
+
+            // Assert
+
+            content.Assets.Should().HaveCount(1);
+        }
+    }
+}

--- a/HousingSearchApi/V1/Helper/CustomAddressSorter.cs
+++ b/HousingSearchApi/V1/Helper/CustomAddressSorter.cs
@@ -37,6 +37,9 @@ namespace HousingSearchApi.V1.Helper
 
             if (!string.IsNullOrEmpty(asset.AssetAddress.PostCode) && asset.AssetAddress.PostCode.ToLower().Replace(" ", "").Contains(searchModel.SearchText.ToLower().Replace(" ", ""))) return true;
 
+            // UPRN
+            if (!string.IsNullOrEmpty(asset.AssetId) && asset.AssetId.ToLower() == searchModel.SearchText.ToLower()) return true;
+
             return false;
         };
     }

--- a/HousingSearchApi/V1/Helper/CustomAddressSorter.cs
+++ b/HousingSearchApi/V1/Helper/CustomAddressSorter.cs
@@ -38,7 +38,7 @@ namespace HousingSearchApi.V1.Helper
             if (!string.IsNullOrEmpty(asset.AssetAddress.PostCode) && asset.AssetAddress.PostCode.ToLower().Replace(" ", "").Contains(searchModel.SearchText.ToLower().Replace(" ", ""))) return true;
 
             // UPRN
-            if (!string.IsNullOrEmpty(asset.AssetId) && asset.AssetId.ToLower() == searchModel.SearchText.ToLower()) return true;
+            if (!string.IsNullOrEmpty(asset.AssetId) && asset.AssetId.Trim().ToLower() == searchModel.SearchText.Trim().ToLower()) return true;
 
             return false;
         };


### PR DESCRIPTION
## Summary of Changes

Users reported they could not search for properties with a URPN. The change came after improvements to the housing search.

The solution was to include a URPN check in the `CustomAddressSorter` class. I'm using a direct comparison for UPRN rather than contains to avoid returning partial matching results. 

[Halo Ticket](https://hackney.haloitsm.com/tickets?showmenu=true&mainview=team&viewid=14&selid=1&sellevel=2&selparentid=mt%20for%20housing&id=89182)