### PR TITLE
Resolve exception in search sorting

### DIFF
--- a/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
@@ -1,4 +1,3 @@
-using Bogus;
 using FluentAssertions;
 using Hackney.Shared.HousingSearch.Domain.Asset;
 using HousingSearchApi.V1.Helper;
@@ -51,8 +50,8 @@ namespace HousingSearchApi.Tests.V1.Helper
 
             var address2 = new AssetAddress
             {
-                AddressLine1 = "2 Pitcairn House",
-                AddressLine2 = "St Thomass Square"
+                AddressLine1 = "2",
+                AddressLine2 = "Pitcairn House St Thomass Square"
             };
 
 

--- a/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
@@ -1,0 +1,43 @@
+using Bogus;
+using FluentAssertions;
+using Hackney.Shared.HousingSearch.Domain.Asset;
+using HousingSearchApi.V1.Helper;
+using System;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.Helper
+{
+    public class AddressComparerTests
+    {
+        private readonly AddressComparer _classUnderTest;
+
+        public AddressComparerTests()
+        {
+            _classUnderTest = new AddressComparer();
+        }
+
+
+        [Fact]
+        public void Compare_DoesntThrowException_WhenAddressLine1ContainsNoSpaces()
+        {
+            // Arrange
+            var address1 = new AssetAddress
+            {
+                AddressLine1 = "71A",
+                AddressLine2 = "GREENWOOD ROAD"
+            };
+
+            var address2 = new AssetAddress
+            {
+                AddressLine1 = "1 Pitcairn House"
+            };
+
+
+            // Act
+            Func<int> func = () => _classUnderTest.Compare(address1, address2);
+
+            // Assert
+            func.Should().NotThrow();
+        }
+    }
+}

--- a/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
+++ b/HousingSearchApi.Tests/V1/Helper/AddressComparerTests.cs
@@ -16,7 +16,6 @@ namespace HousingSearchApi.Tests.V1.Helper
             _classUnderTest = new AddressComparer();
         }
 
-
         [Fact]
         public void Compare_DoesntThrowException_WhenAddressLine1ContainsNoSpaces()
         {
@@ -38,6 +37,30 @@ namespace HousingSearchApi.Tests.V1.Helper
 
             // Assert
             func.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Compare_WhenTheStreetIsTheSame_ReturnsTheAddressesSortedByNumber()
+        {
+            // Arrange
+            var address1 = new AssetAddress
+            {
+                AddressLine1 = "1 Pitcairn House",
+                AddressLine2 = "St Thomass Square"
+            };
+
+            var address2 = new AssetAddress
+            {
+                AddressLine1 = "2 Pitcairn House",
+                AddressLine2 = "St Thomass Square"
+            };
+
+
+            // Act
+            var result = _classUnderTest.Compare(address1, address2);
+
+            // Assert
+            result.Should().Be(-1);
         }
     }
 }

--- a/HousingSearchApi/V1/Helper/AddressComparer.cs
+++ b/HousingSearchApi/V1/Helper/AddressComparer.cs
@@ -1,8 +1,6 @@
 using Hackney.Shared.HousingSearch.Domain.Asset;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace HousingSearchApi.V1.Helper
 {

--- a/HousingSearchApi/V1/Helper/AddressComparer.cs
+++ b/HousingSearchApi/V1/Helper/AddressComparer.cs
@@ -20,16 +20,25 @@ namespace HousingSearchApi.V1.Helper
                 }
             }
 
-            var addressline1_1 = address1.AddressLine1.Split(' ');
-            var addressline1_2 = address2.AddressLine1.Split(' ');
+            var address1Parts = address1.AddressLine1.Split(' ');
+            var address2Parts = address2.AddressLine1.Split(' ');
 
-            if (addressline1_1[1] == addressline1_2[1]
-                && int.TryParse(addressline1_1[0], out var house1)
-                && int.TryParse(addressline1_2[0], out var house2))
+            // prevent IndexOutOfRange exception (addressLine1 contains no spaces)
+            if (address1Parts.Length >= 2 && address2Parts.Length >= 2)
             {
-                return house1 - house2;
+                // if the street is the same, try compare house number
+                if (address1Parts[1] == address2Parts[1]
+                    && int.TryParse(address1Parts[0], out var house1)
+                    && int.TryParse(address2Parts[0], out var house2))
+                {
+                    return house1 - house2;
+                }
+
+                return address1Parts[1].CompareTo(address2Parts[1]);
             }
-            return addressline1_1[1].CompareTo(addressline1_2[1]);
+
+            // default sorting - compare addresssLine1 alphabetically
+            return string.Compare(address1.AddressLine1, address2.AddressLine1);
         }
 
         private static int? TryParseFlatNumber(AssetAddress address)

--- a/HousingSearchApi/V1/Helper/AddressComparer.cs
+++ b/HousingSearchApi/V1/Helper/AddressComparer.cs
@@ -1,6 +1,8 @@
 using Hackney.Shared.HousingSearch.Domain.Asset;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace HousingSearchApi.V1.Helper
 {
@@ -20,11 +22,11 @@ namespace HousingSearchApi.V1.Helper
                 }
             }
 
-            var address1Parts = address1.AddressLine1.Split(' ');
-            var address2Parts = address2.AddressLine1.Split(' ');
+            var address1Parts = ExtractAddressParts(address1);
+            var address2Parts = ExtractAddressParts(address2);
 
             // prevent IndexOutOfRange exception (addressLine1 contains no spaces)
-            if (address1Parts.Length >= 2 && address2Parts.Length >= 2)
+            if (address1Parts.Count >= 2 && address2Parts.Count >= 2)
             {
                 // if the street is the same, try compare house number
                 if (address1Parts[1] == address2Parts[1]
@@ -38,7 +40,26 @@ namespace HousingSearchApi.V1.Helper
             }
 
             // default sorting - compare addresssLine1 alphabetically
-            return string.Compare(address1.AddressLine1, address2.AddressLine1);
+            return address1.AddressLine1.CompareTo(address2.AddressLine1);
+        }
+
+        private static List<string> ExtractAddressParts(AssetAddress address)
+        {
+            var addressParts = new List<string> { };
+
+            // the relevant parts of the address will be in lines 1 and 2
+
+            if (!string.IsNullOrWhiteSpace(address.AddressLine1))
+            {
+                addressParts.AddRange(address.AddressLine1.Split(' '));
+            }
+
+            if (!string.IsNullOrWhiteSpace(address.AddressLine2))
+            {
+                addressParts.AddRange(address.AddressLine2.Split(' '));
+            }
+
+            return addressParts;
         }
 
         private static int? TryParseFlatNumber(AssetAddress address)


### PR DESCRIPTION
## Summary of Changes

The following address caused an error when calling the search endpoint:
```json
{
  "uprn": "200002791530",
  "addressLine1": "71A",
  "addressLine2": "GREENWOOD ROAD"
}
```

`Unable to sort because the IComparer.Compare() method returns inconsistent results. Either a value does not compare equal to itself, or one value repeatedly compared to another value yields different results. IComparer: 'System.Comparison'1[System.Int32]'`. 

The above exception was actually caused by an `IndexOutOfRangeException` (AddressLine1 contains no spaces, so after splitting the string into an array, it would only have one element).

To prevent the exception, I have added a check to assert that both arrays contain at least two elements. I then added a default sort option (which should rarely be used).

![image](https://github.com/LBHackney-IT/housing-search-api/assets/88662046/108a2974-ea3f-4690-aa26-6e9726b8a68d)

Secondly, I updated the logic that splits address arrays to include `AddressLine2`. 

![image](https://github.com/LBHackney-IT/housing-search-api/assets/88662046/29a1adc8-aa82-4d06-a35f-505f30329f54)
