### PR TITLE
Increase results

### DIFF
--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -82,7 +82,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
             var response = await _searchGateway.GetListOfAssets(query);
 
             // Assert
-            query.PageSize.Should().Be(400);
+            query.PageSize.Should().Be(650);
         }
 
         [Fact]

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -69,7 +69,7 @@ namespace HousingSearchApi.V1.Gateways
         [LogCall]
         public async Task<GetAssetListResponse> GetListOfAssets(GetAssetListRequest query)
         {
-            const int CustomSortPageSize = 400;
+            const int CustomSortPageSize = 650;
 
             if (query.UseCustomSorting)
             {


### PR DESCRIPTION
- https://hackney.atlassian.net/browse/MR-753 states that Fellow's Court can't be found
- The reason being is that the max results is set at 400, and this estate has around 470 properties + other assets.
- Therefore, set the max results to 650. With this limit set, locally, the WalkUpBlocks are included in the results
![image](https://github.com/LBHackney-IT/housing-search-api/assets/8542878/4ad90e08-8179-4aa4-8be0-7cc9287f176f)
