### PR TITLE
Filter out partially matched related assets

### DIFF
--- a/HousingSearchApi.Tests/V1/UseCases/GetAssetRelationshipsUseCaseTests.cs
+++ b/HousingSearchApi.Tests/V1/UseCases/GetAssetRelationshipsUseCaseTests.cs
@@ -102,5 +102,43 @@ namespace HousingSearchApi.Tests.V1.UseCases
 
             result.ChildAssets.Should().HaveCount(assetList.Count - 1);
         }
+
+        [Fact]
+        public async Task ShouldNotFilterOutResultsWithMultipleParents()
+        {
+            // Arrange
+            var parentId = "854cd27e-AAAA-a312-c510-bec6f816ec5c";
+
+            var assetList = new List<Asset>
+            {
+                new Asset
+                {
+                    AssetId = "TEST0001",
+                    ParentAssetIds = parentId
+                },
+                new Asset
+                {
+                    AssetId = "TEST0002",
+                    ParentAssetIds = $"{parentId}#28d4c9f2-1bf7-4c38-a174-76211214d738"
+                }
+            };
+
+            _searchGatewayMock
+                .Setup(x => x.GetChildAssets(It.IsAny<GetAssetRelationshipsRequest>()))
+                .ReturnsAsync(assetList);
+
+            var request = new GetAssetRelationshipsRequest
+            {
+                SearchText = parentId,
+            };
+
+            // Act
+            var result = await _sut.ExecuteAsync(request);
+
+            // Assert
+            result.Should().BeOfType<GetAssetRelationshipsResponse>();
+
+            result.ChildAssets.Should().HaveCount(assetList.Count);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/UseCases/GetAssetRelationshipsUseCaseTests.cs
+++ b/HousingSearchApi.Tests/V1/UseCases/GetAssetRelationshipsUseCaseTests.cs
@@ -43,7 +43,8 @@ namespace HousingSearchApi.Tests.V1.UseCases
                 }
             };
 
-            _searchGatewayMock.Setup(x => x.GetChildAssets(Moq.It.IsAny<GetAssetRelationshipsRequest>()))
+            _searchGatewayMock
+                .Setup(x => x.GetChildAssets(It.IsAny<GetAssetRelationshipsRequest>()))
                 .ReturnsAsync(assetList);
 
             var request = new GetAssetRelationshipsRequest
@@ -61,6 +62,45 @@ namespace HousingSearchApi.Tests.V1.UseCases
             {
                 asset.ParentAssetIds.Should().Contain(parentId);
             }
+        }
+
+        [Fact]
+        public async Task ShouldFilterOutPartiallyMatchedResults()
+        {
+            // Arrange
+            var parentId = "854cd27e-AAAA-a312-c510-bec6f816ec5c";
+
+            var assetList = new List<Asset>
+            {
+                new Asset
+                {
+                    AssetId = "TEST0001",
+                    // Id matches only by "AAAA"
+                    ParentAssetIds = "bb07d466-3d5d-a158-AAAA-eb5639e71292"
+                },
+                new Asset
+                {
+                    AssetId = "TEST0002",
+                    ParentAssetIds = parentId
+                }
+            };
+
+            _searchGatewayMock
+                .Setup(x => x.GetChildAssets(It.IsAny<GetAssetRelationshipsRequest>()))
+                .ReturnsAsync(assetList);
+
+            var request = new GetAssetRelationshipsRequest
+            {
+                SearchText = parentId,
+            };
+
+            // Act
+            var result = await _sut.ExecuteAsync(request);
+
+            // Assert
+            result.Should().BeOfType<GetAssetRelationshipsResponse>();
+
+            result.ChildAssets.Should().HaveCount(assetList.Count - 1);
         }
     }
 }


### PR DESCRIPTION
## Describe this PR

The assetrelationships endpoint returns results with a partially matched GUID.

For example, if the query is `854cd27e-bffa-a312-c510`, it will match with `bb07d466-3d5d-a158-bffa` because they both include `bffa`. However, we cannot implement an exact match because some assets have multiple parent assets, separated by a `#`. 

The solution I have implemented here will run a contains filter on the result, and will filter out any partial matches. 