### PR TITLE
Add tenure type filtering

### DIFF
--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -33,5 +33,8 @@ namespace HousingSearchApi.V1.Boundary.Requests
 
         [FromQuery(Name = "parentAssetId")]
         public string ParentAssetId { get; set; }
+
+        [FromQuery(Name = "tenureType")]
+        public string TenureType { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -77,6 +77,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.PrivateKitchen, new List<string> { "assetCharacteristics.hasPrivateKitchen" })
                         .WithMultipleFilterQuery(assetListAllRequest.StepFree, new List<string> { "assetCharacteristics.isStepFree" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsTemporaryAccomodation, new List<string> { "assetManagement.isTemporaryAccomodation" })
+                        .WithMultipleFilterQuery(assetListAllRequest.TenureType, new List<string> { "tenure.type.keyword" })
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
@@ -109,6 +110,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.PrivateKitchen, new List<string> { "assetCharacteristics.hasPrivateKitchen" })
                         .WithMultipleFilterQuery(assetListAllRequest.StepFree, new List<string> { "assetCharacteristics.isStepFree" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsTemporaryAccomodation, new List<string> { "assetManagement.isTemporaryAccomodation" })
+                        .WithMultipleFilterQuery(assetListAllRequest.TenureType, new List<string> { "tenure.type.keyword" })
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })


### PR DESCRIPTION
## Link to JIRA ticket

[TS-785: Add tenure type filtering](https://hackney.atlassian.net/browse/TS-785)

## Describe this PR

### *What is the problem we're trying to solve*

Allow the housing search API to filter assets based on their corresponding tenure type. That is, the type of the tenure that is currently attached to the asset.

### *What changes have we introduced*

The field already existed in OpenSearch, so we have amended the `GetAllAssetListRequest` class to capture a `tenureType` querystring parameter, and this is wired through to a query within the `AssetQueryGenerator`.

### *Follow up actions after merging PR*

Amend the Swagger for the housing API to include the new parameter.
