### PR TITLE
TS-1390 Add temporary accommodation booking status support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty @LBHackney-IT/mtfh-manage-my-home
+* @LBHackney-IT/mtfh-manage-my-home

--- a/HousingSearchApi.Tests/Dockerfile
+++ b/HousingSearchApi.Tests/Dockerfile
@@ -11,8 +11,8 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-11-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
+RUN apt-get update && apt-get install -y openjdk-17-jdk
+RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
 RUN dotnet sonarscanner begin /k:"LBHackney-IT_housing-search-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0009" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.69.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0009" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1390](https://hackney.atlassian.net/browse/TS-1390)

## Describe this PR

### *What is the problem we're trying to solve*

Currently used version of the `Hackney.Shared.HousingSearch.Domain.Tenure` package does not include booking status details for Temporary Accommodation which is required for new TA worktray feature. 

### *What changes have we introduced*

1.  This updates the `Hackney.Shared.HousingSearch.Domain.Tenure` to version `0.70.0` [[link](https://github.com/LBHackney-IT/housing-search-shared/pull/73)] which includes the new `TempAccommodationInfo` property which includes the booking status details. Changes to Tenure object are the responsibility of the shared package, so test coverage for the new property is covered in that package's repo. 
2. [Unrelated] Update for SonarCloud config for testing because the currentt setup is out of date and no longer works in the pipeline
4. [Unrelated] Update the code owners file to reflect the current structure
5. [Unrelated] Update vulnerable SwaggerUI package that caused the build to fail
 
#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly


[TS-1390]: https://hackney.atlassian.net/browse/TS-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ