### PR TITLE
TS-1325: Filter TA tenures by booking status

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -103,5 +103,53 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             Thread.Sleep(10000);
         }
+
+        public void GivenTaTenuresExist(int tenuresToCreate)
+        {
+            var listOfTenures = new List<QueryableTenure>();
+            var fixture = new Fixture();
+            for (var i = 0; i < tenuresToCreate; i++)
+            {
+                var tenure = fixture.Create<QueryableTenure>();
+                tenure.TenuredAsset.IsTemporaryAccommodation = true;
+
+                listOfTenures.Add(tenure);
+            }
+
+            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+
+            while (!awaitable.GetAwaiter().IsCompleted) { }
+
+            Thread.Sleep(10000);
+        }
+
+        public void GivenSimilarTaTenuresExist(string bookingStatus, string fullName)
+        {
+            var fixture = new Fixture();
+            var listOfTenures = new List<QueryableTenure>();
+
+            var firstTenure = fixture.Create<QueryableTenure>();
+            firstTenure.TenuredAsset.IsTemporaryAccommodation = true;
+            firstTenure.TempAccommodationInfo.BookingStatus = bookingStatus;
+
+            listOfTenures.Add(firstTenure);
+
+            var secondTenure = fixture.Create<QueryableTenure>();
+            secondTenure.TenuredAsset.IsTemporaryAccommodation = true;
+            secondTenure.HouseholdMembers.First().FullName = fullName;
+            listOfTenures.Add(secondTenure);
+
+            var thirdTenure = fixture.Create<QueryableTenure>();
+            thirdTenure.TenuredAsset.IsTemporaryAccommodation = true;
+            thirdTenure.TempAccommodationInfo.BookingStatus = bookingStatus;
+            thirdTenure.HouseholdMembers.First().FullName = fullName;
+            listOfTenures.Add(thirdTenure);
+
+            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+
+            while (!awaitable.GetAwaiter().IsCompleted) { }
+
+            Thread.Sleep(10000);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -104,6 +104,23 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             Thread.Sleep(10000);
         }
 
+        public void GivenATenureWithSpecificUprn(string uprn)
+        {
+            var fixture = new Fixture();
+            var listOfTenures = new List<QueryableTenure>();
+
+            var tenure = fixture.Create<QueryableTenure>();
+            tenure.TenuredAsset.Uprn = uprn;
+
+            listOfTenures.Add(tenure);
+
+            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+
+            while (!awaitable.GetAwaiter().IsCompleted) { }
+
+            Thread.Sleep(10000);
+        }
+
         public void GivenTaTenuresExist(int tenuresToCreate)
         {
             var listOfTenures = new List<QueryableTenure>();

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -18,6 +18,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         private const string INDEX = "tenures";
         public static string[] Alphabet = { "aa", "bb", "cc", "dd", "ee", "vv", "ww", "xx", "yy", "zz" };
 
+        private readonly Fixture _fixture = new Fixture();
+
         public TenureFixture(IElasticClient elasticClient, HttpClient httpClient) : base(elasticClient, httpClient)
         {
             WaitForESInstance();
@@ -49,13 +51,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         {
             var listOfTenures = new List<QueryableTenure>();
             var random = new Random();
-            var fixture = new Fixture();
 
             foreach (var value in Alphabet)
             {
                 for (int i = 0; i < 10; i++)
                 {
-                    var tenure = fixture.Create<QueryableTenure>();
+                    var tenure = _fixture.Create<QueryableTenure>();
                     tenure.PaymentReference = value;
 
                     listOfTenures.Add(tenure);
@@ -65,7 +66,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             // Add loads more at random
             for (int i = 0; i < 900; i++)
             {
-                var tenure = fixture.Create<QueryableTenure>();
+                var tenure = _fixture.Create<QueryableTenure>();
 
                 listOfTenures.Add(tenure);
             }
@@ -75,25 +76,24 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
         public void GivenSimilarTenures(string paymentReference, string fullAddress, string fullName)
         {
-            var fixture = new Fixture();
             var listOfTenures = new List<QueryableTenure>();
 
-            var firstTenure = fixture.Create<QueryableTenure>();
+            var firstTenure = _fixture.Create<QueryableTenure>();
             firstTenure.PaymentReference = paymentReference;
             firstTenure.TenuredAsset.FullAddress = fullAddress;
             firstTenure.HouseholdMembers.First().FullName = fullName;
 
             listOfTenures.Add(firstTenure);
 
-            var secondTenure = fixture.Create<QueryableTenure>();
+            var secondTenure = _fixture.Create<QueryableTenure>();
             secondTenure.PaymentReference = paymentReference;
             listOfTenures.Add(secondTenure);
 
-            var thirdTenure = fixture.Create<QueryableTenure>();
+            var thirdTenure = _fixture.Create<QueryableTenure>();
             thirdTenure.TenuredAsset.FullAddress = fullAddress;
             listOfTenures.Add(thirdTenure);
 
-            var forthTenure = fixture.Create<QueryableTenure>();
+            var forthTenure = _fixture.Create<QueryableTenure>();
             thirdTenure.HouseholdMembers.First().FullName = fullName;
             listOfTenures.Add(forthTenure);
 
@@ -106,10 +106,9 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
         public void GivenATenureWithSpecificUprn(string uprn)
         {
-            var fixture = new Fixture();
             var listOfTenures = new List<QueryableTenure>();
 
-            var tenure = fixture.Create<QueryableTenure>();
+            var tenure = _fixture.Create<QueryableTenure>();
             tenure.TenuredAsset.Uprn = uprn;
 
             listOfTenures.Add(tenure);
@@ -124,10 +123,9 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public void GivenTaTenuresExist(int tenuresToCreate)
         {
             var listOfTenures = new List<QueryableTenure>();
-            var fixture = new Fixture();
             for (var i = 0; i < tenuresToCreate; i++)
             {
-                var tenure = fixture.Create<QueryableTenure>();
+                var tenure = _fixture.Create<QueryableTenure>();
                 tenure.TenuredAsset.IsTemporaryAccommodation = true;
 
                 listOfTenures.Add(tenure);
@@ -142,21 +140,20 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
         public void GivenSimilarTaTenuresExist(string bookingStatus, string fullName)
         {
-            var fixture = new Fixture();
             var listOfTenures = new List<QueryableTenure>();
 
-            var firstTenure = fixture.Create<QueryableTenure>();
+            var firstTenure = _fixture.Create<QueryableTenure>();
             firstTenure.TenuredAsset.IsTemporaryAccommodation = true;
             firstTenure.TempAccommodationInfo.BookingStatus = bookingStatus;
 
             listOfTenures.Add(firstTenure);
 
-            var secondTenure = fixture.Create<QueryableTenure>();
+            var secondTenure = _fixture.Create<QueryableTenure>();
             secondTenure.TenuredAsset.IsTemporaryAccommodation = true;
             secondTenure.HouseholdMembers.First().FullName = fullName;
             listOfTenures.Add(secondTenure);
 
-            var thirdTenure = fixture.Create<QueryableTenure>();
+            var thirdTenure = _fixture.Create<QueryableTenure>();
             thirdTenure.TenuredAsset.IsTemporaryAccommodation = true;
             thirdTenure.TempAccommodationInfo.BookingStatus = bookingStatus;
             thirdTenure.HouseholdMembers.First().FullName = fullName;

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
@@ -27,6 +27,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             _lastResponse = await _httpClient.GetAsync(new Uri("api/v1/search/tenures?searchText=abc", UriKind.Relative)).ConfigureAwait(false);
         }
 
+        public async Task WhenRequestContainsUprn(string uprn)
+        {
+            _lastResponse = await _httpClient.GetAsync(new Uri($"api/v1/search/tenures?uprn={uprn}", UriKind.Relative)).ConfigureAwait(false);
+        }
+
         public async Task WhenSearchingForAllTaTenures()
         {
             _lastResponse = await _httpClient.GetAsync(new Uri("api/v1/search/tenures?searchText=\"\"&isTemporaryAccommodation=true", UriKind.Relative)).ConfigureAwait(false);
@@ -76,6 +81,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Tenures.First().PaymentReference.Should().Be(paymentReference);
             result.Results.Tenures.First().TenuredAsset.FullAddress.Should().Be(fullAddress);
             result.Results.Tenures.First().HouseholdMembers.First().FullName.Should().Be(fullName);
+        }
+
+        public async Task ThenTheReturningResultShouldBeTheSpecificTenure(string uprn)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Tenures.Count.Should().Be(1);
+            result.Results.Tenures.First().TenuredAsset.Uprn.Should().Be(uprn);
         }
 
         public async Task ThenTheReturningResultsShouldIncludeAllTaTenures(int amountOfTaTenures)

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
@@ -83,12 +83,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Tenures.First().HouseholdMembers.First().FullName.Should().Be(fullName);
         }
 
-        public async Task ThenTheReturningResultShouldBeTheSpecificTenure(string uprn)
+        public async Task ThenTheReturningResultShouldBeTheSpecificTenure(string uprn, int tenureCount)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
 
-            result.Results.Tenures.Count.Should().Be(1);
+            result.Results.Tenures.Count.Should().Be(tenureCount);
             result.Results.Tenures.First().TenuredAsset.Uprn.Should().Be(uprn);
         }
 
@@ -106,39 +106,39 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             }
         }
 
-        public async Task ThenTheReturningResultsShouldBeTheFilteredTaTenures(string bookingStatus)
+        public async Task ThenTheReturningResultsShouldBeTheFilteredTaTenures(string bookingStatus, int tenureCount)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
 
             var tenures = result.Results.Tenures;
-            tenures.Count.Should().Be(2);
+            tenures.Count.Should().Be(tenureCount);
             foreach (var tenure in tenures)
             {
                 tenure.TempAccommodationInfo.BookingStatus.Should().Be(bookingStatus);
             }
         }
 
-        public async Task ThenTheReturningResultsShouldBeTheSearchedTaTenures(string fullName)
+        public async Task ThenTheReturningResultsShouldBeTheSearchedTaTenures(string fullName, int tenureCount)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
 
             var tenures = result.Results.Tenures;
-            tenures.Count.Should().Be(2);
+            tenures.Count.Should().Be(tenureCount);
             foreach (var tenure in tenures)
             {
                 tenure.HouseholdMembers.First().FullName.Should().Be(fullName);
             }
         }
 
-        public async Task ThenTheReturningResultShouldHaveTheSpecificTaTenure(string bookingStatus, string fullName)
+        public async Task ThenTheReturningResultShouldHaveTheSpecificTaTenure(string bookingStatus, string fullName, int tenureCount)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
 
             var tenures = result.Results.Tenures;
-            tenures.Count.Should().Be(1);
+            tenures.Count.Should().Be(tenureCount);
             tenures.First().TempAccommodationInfo.BookingStatus.Should().Be(bookingStatus);
             tenures.First().HouseholdMembers.First().FullName.Should().Be(fullName);
         }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
@@ -62,6 +62,17 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenTheFirstOfTheReturningResultsShouldBeTheMostRelevantOne("FirstEntry", "SecondEntry", "ThirdEntry"))
                 .BDDfy();
         }
+
+        [Fact]
+        public void ServiceReturnSpecificTenureByUprn()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenATenureWithSpecificUprn("12345678"))
+                .When(w => _steps.WhenRequestContainsUprn("12345678"))
+                .Then(t => _steps.ThenTheReturningResultShouldBeTheSpecificTenure("12345678"))
+                .BDDfy();
+        }
+
         [Fact]
         public void ServiceReturnsAllTaTenures()
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
@@ -62,5 +62,48 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenTheFirstOfTheReturningResultsShouldBeTheMostRelevantOne("FirstEntry", "SecondEntry", "ThirdEntry"))
                 .BDDfy();
         }
+        [Fact]
+        public void ServiceReturnsAllTaTenures()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .When(w => _steps.WhenSearchingForAllTaTenures())
+                .Then(t => _steps.ThenTheReturningResultsShouldIncludeAllTaTenures(5))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsFilteredByBookingStatusTaTenures()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForTaTenuresWithABookingStatusAndNoSearchText("ACC"))
+                .Then(t => _steps.ThenTheReturningResultsShouldBeTheFilteredTaTenures("ACC"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsTaTenuresWhenSearchedByNameButNotFilteredByBookingStatus()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForASpecificTaTenureByTenantFullName("John Doe"))
+                .Then(t => _steps.ThenTheReturningResultsShouldBeTheSearchedTaTenures("John Doe"))
+                .BDDfy();
+        }
+
+
+        [Fact]
+        public void ServiceReturnsSpecificTenuresWhenSearchedByNameAndFilteredByBookingStatus()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForASpecificTaTenureByBookingStatusAndTenantFullName("ACC", "John Doe"))
+                .Then(t => _steps.ThenTheReturningResultShouldHaveTheSpecificTaTenure("ACC", "John Doe"))
+                .BDDfy();
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
@@ -69,7 +69,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             this.Given(g => _tenureFixture.GivenATenureIndexExists())
                 .Given(g => _tenureFixture.GivenATenureWithSpecificUprn("12345678"))
                 .When(w => _steps.WhenRequestContainsUprn("12345678"))
-                .Then(t => _steps.ThenTheReturningResultShouldBeTheSpecificTenure("12345678"))
+                .Then(t => _steps.ThenTheReturningResultShouldBeTheSpecificTenure("12345678", 1))
                 .BDDfy();
         }
 
@@ -90,7 +90,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Given(g => _tenureFixture.GivenTaTenuresExist(5))
                 .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
                 .When(w => _steps.WhenSearchingForTaTenuresWithABookingStatusAndNoSearchText("ACC"))
-                .Then(t => _steps.ThenTheReturningResultsShouldBeTheFilteredTaTenures("ACC"))
+                .Then(t => _steps.ThenTheReturningResultsShouldBeTheFilteredTaTenures("ACC", 2))
                 .BDDfy();
         }
 
@@ -101,7 +101,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Given(g => _tenureFixture.GivenTaTenuresExist(5))
                 .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
                 .When(w => _steps.WhenSearchingForASpecificTaTenureByTenantFullName("John Doe"))
-                .Then(t => _steps.ThenTheReturningResultsShouldBeTheSearchedTaTenures("John Doe"))
+                .Then(t => _steps.ThenTheReturningResultsShouldBeTheSearchedTaTenures("John Doe", 2))
                 .BDDfy();
         }
 
@@ -113,7 +113,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Given(g => _tenureFixture.GivenTaTenuresExist(5))
                 .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
                 .When(w => _steps.WhenSearchingForASpecificTaTenureByBookingStatusAndTenantFullName("ACC", "John Doe"))
-                .Then(t => _steps.ThenTheReturningResultShouldHaveTheSpecificTaTenure("ACC", "John Doe"))
+                .Then(t => _steps.ThenTheReturningResultShouldHaveTheSpecificTaTenure("ACC", "John Doe", 1))
                 .BDDfy();
         }
     }

--- a/HousingSearchApi/V1/Boundary/Requests/GetTenureListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetTenureListRequest.cs
@@ -6,5 +6,11 @@ namespace HousingSearchApi.V1.Boundary.Requests
     {
         [FromQuery(Name = "uprn")]
         public string Uprn { get; set; }
+
+        [FromQuery(Name = "bookingStatus")]
+        public string BookingStatus { get; set; }
+
+        [FromQuery(Name = "isTemporaryAccommodation")]
+        public string IsTemporaryAccommodation { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Factories/QueryFactory.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/QueryFactory.cs
@@ -30,7 +30,8 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
 
             if (typeof(T) == typeof(QueryableTenure))
             {
-                return (IQueryGenerator<T>) new TenureQueryGenerator(_serviceProvider.GetService<IQueryBuilder<QueryableTenure>>());
+                return (IQueryGenerator<T>) new TenureQueryGenerator(_serviceProvider.GetService<IQueryBuilder<QueryableTenure>>(),
+                    _serviceProvider.GetService<IFilterQueryBuilder<QueryableTenure>>());
             }
 
             if (typeof(T) == typeof(QueryableAsset))

--- a/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Hackney.Core.ElasticSearch.Interfaces;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
-using Hackney.Shared.Tenure.Domain;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Interfaces;
 using HousingSearchApi.V1.Interfaces.Factories;
@@ -35,19 +34,8 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (tenureListRequest.SearchText != null && tenureListRequest.SearchText.Length > 0)
             {
 
-                // return _queryBuilder
-                // .WithWildstarQuery(tenureListRequest.SearchText, new List<string>
-                // {
-                //     "paymentReference",
-                //     "tenuredAsset.fullAddress^3",
-                //     "householdMembers",
-                //     "householdMembers.fullName^3",
-                // })
-                // .Build(q);
-
-
                 return _queryFilterBuilder
-                    .WithMultipleFilterQuery(tenureListRequest.IsTemporaryAccommodation,new List<string> { "tenuredAsset.isTemporaryAccommodation" } )
+                    .WithMultipleFilterQuery(tenureListRequest.IsTemporaryAccommodation, new List<string> { "tenuredAsset.isTemporaryAccommodation" })
                     .WithFilterQuery(tenureListRequest.BookingStatus, new List<string> { "tempAccommodationInfo.bookingStatus" })
                     .WithWildstarQuery(tenureListRequest.SearchText,
                         new List<string>

--- a/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/TenureQueryGenerator.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using Hackney.Core.ElasticSearch.Interfaces;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
+using Hackney.Shared.Tenure.Domain;
 using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Interfaces;
 using HousingSearchApi.V1.Interfaces.Factories;
 using Nest;
 
@@ -11,10 +13,13 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
     public class TenureQueryGenerator : IQueryGenerator<QueryableTenure>
     {
         private readonly IQueryBuilder<QueryableTenure> _queryBuilder;
+        private readonly IFilterQueryBuilder<QueryableTenure> _queryFilterBuilder;
 
-        public TenureQueryGenerator(IQueryBuilder<QueryableTenure> queryBuilder)
+        public TenureQueryGenerator(IQueryBuilder<QueryableTenure> queryBuilder,
+            IFilterQueryBuilder<QueryableTenure> queryFilterBuilder)
         {
             _queryBuilder = queryBuilder;
+            _queryFilterBuilder = queryFilterBuilder;
         }
 
         public QueryContainer Create<TRequest>(TRequest request, QueryContainerDescriptor<QueryableTenure> q)
@@ -30,15 +35,29 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
             if (tenureListRequest.SearchText != null && tenureListRequest.SearchText.Length > 0)
             {
 
-                return _queryBuilder
-                .WithWildstarQuery(tenureListRequest.SearchText, new List<string>
-                {
-                    "paymentReference",
-                    "tenuredAsset.fullAddress^3",
-                    "householdMembers",
-                    "householdMembers.fullName^3"
-                })
-                .Build(q);
+                // return _queryBuilder
+                // .WithWildstarQuery(tenureListRequest.SearchText, new List<string>
+                // {
+                //     "paymentReference",
+                //     "tenuredAsset.fullAddress^3",
+                //     "householdMembers",
+                //     "householdMembers.fullName^3",
+                // })
+                // .Build(q);
+
+
+                return _queryFilterBuilder
+                    .WithMultipleFilterQuery(tenureListRequest.IsTemporaryAccommodation,new List<string> { "tenuredAsset.isTemporaryAccommodation" } )
+                    .WithFilterQuery(tenureListRequest.BookingStatus, new List<string> { "tempAccommodationInfo.bookingStatus" })
+                    .WithWildstarQuery(tenureListRequest.SearchText,
+                        new List<string>
+                        {
+                            "paymentReference",
+                            "tenuredAsset.fullAddress^3",
+                            "householdMembers",
+                            "householdMembers.fullName^3",
+                        })
+                    .Build(q);
             }
             else
             {


### PR DESCRIPTION
### What
This PR adds to the tenure search functionality the ability to retrieve only temporary accommodation tenures and filter them by booking status. This is done by updating the `TenureQueryGenerator` which creates the search query to be able to filter TA tenures either with or without a booking status. The respective request model has also been updated to allow such functionality.
### Why
The BTA worktray should only show TA tenures rather than all of them. Furthermore users should have the ability to filter these tenures by their booking status
### Notes
The tests for the `TenureQueryGenerator` itself shall come in a PR after this one.