### PR TITLE
TS-1325 Add tenure query generator test coverage

### DIFF
--- a/HousingSearchApi.Tests/V1/Factories/TenureQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/TenureQueryGeneratorTests.cs
@@ -1,0 +1,165 @@
+using AutoFixture;
+using Hackney.Core.ElasticSearch.Interfaces;
+using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Infrastructure.Factories;
+using HousingSearchApi.V1.Interfaces;
+using Moq;
+using Nest;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.Factories
+{
+    public class TenureQueryGeneratorTests
+    {
+        private readonly TenureQueryGenerator _sut;
+        private readonly QueryContainerDescriptor<QueryableTenure> _queryContainerDescriptor;
+        private readonly Mock<IQueryBuilder<QueryableTenure>> _queryBuilderMock;
+        private readonly Mock<IFilterQueryBuilder<QueryableTenure>> _queryFilterBuilderMock;
+        private readonly Fixture _fixure;
+        private readonly GetTenureListRequest _request;
+
+        public TenureQueryGeneratorTests()
+        {
+            _queryBuilderMock = new Mock<IQueryBuilder<QueryableTenure>>();
+            _queryFilterBuilderMock = new Mock<IFilterQueryBuilder<QueryableTenure>>();
+            _fixure = new Fixture();
+            _request = _fixure.Build<GetTenureListRequest>().Create();
+            _queryContainerDescriptor = new QueryContainerDescriptor<QueryableTenure>();
+            _sut = new TenureQueryGenerator(_queryBuilderMock.Object, _queryFilterBuilderMock.Object);
+        }
+
+        [Fact]
+        public void CreateThrowsArgumentNullExceptionWithAMessageWhenRequestIsNotGetTenureListRequestType()
+        {
+            //Arrange
+            var request = new object();
+            var expectedExceptionMessage = "Value cannot be null. (Parameter 'request shouldn't be null.')";
+
+            //Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => _sut.Create(request, _queryContainerDescriptor));
+            Assert.Equal(expectedExceptionMessage, ex.Message);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CreateThrowsArgumentNullExceptionWithAMessageWhenBothSearchTextAndUprnAreNullOrEmpty(string input)
+        {
+            //Arrange
+            _request.SearchText = input;
+            _request.Uprn = input;
+
+            var expectedExceptionMessage = "Value cannot be null. (Parameter 'request should include seachText or Uprn.')";
+
+            //Act and assert
+            var ex = Assert.Throws<ArgumentNullException>(() => _sut.Create(_request, _queryContainerDescriptor));
+            Assert.Equal(expectedExceptionMessage, ex.Message);
+        }
+
+        [Fact]
+        public void CreateCallsQueryBuilderWhenSearchTextIsEmptyAndUprnIsProvided()
+        {
+            // Arrange
+            _request.SearchText = "";
+
+            _queryBuilderMock
+                .Setup(x =>
+                    x.WithExactQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<IExactSearchQuerystringProcessor>(), It.IsAny<TextQueryType>())
+                    .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>())).Verifiable();
+
+            // Act
+            _sut.Create(_request, _queryContainerDescriptor);
+
+            // Assert
+            _queryBuilderMock.Verify();
+        }
+
+        [Fact]
+        public void CreateCallsQueryFilterBuilderWhenSearchTextIsNotNullAndIsLongerThanZero()
+        {
+            // Arrange
+            _queryFilterBuilderMock.Setup(x =>
+                x.WithMultipleFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>())
+                .WithFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+                .WithWildstarQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+                .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>())).Verifiable();
+
+            // Act
+            _sut.Create(_request, _queryContainerDescriptor);
+
+            //Assert
+            _queryFilterBuilderMock.Verify();
+        }
+
+        [Fact]
+        public void CreateGeneratesCorrectQueryWhenUsingWildstarQuery()
+        {
+            // Arrange
+            var expectedMultipleFilterQueryFields = new List<string>()
+            {
+                 "tenuredAsset.isTemporaryAccommodation"
+            };
+
+            var expectedWithFilterQueryFields = new List<string>()
+            {
+                "tempAccommodationInfo.bookingStatus"
+            };
+
+            var expectedWildstarFields = new List<string>()
+            {
+                "paymentReference",
+                "tenuredAsset.fullAddress^3",
+                "householdMembers",
+                "householdMembers.fullName^3"
+            };
+
+            var expectedTextQueryType = TextQueryType.MostFields;
+
+            _queryFilterBuilderMock.Setup(x =>
+                x.WithMultipleFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>())
+                .WithFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+                .WithWildstarQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+                .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>()));
+
+            // Act
+            _ = _sut.Create(_request, _queryContainerDescriptor);
+
+            // Assert
+            _queryFilterBuilderMock.Verify(x =>
+                x.WithMultipleFilterQuery(_request.IsTemporaryAccommodation, expectedMultipleFilterQueryFields)
+                .WithFilterQuery(_request.BookingStatus, expectedWithFilterQueryFields, It.IsAny<TextQueryType>())
+                .WithWildstarQuery(_request.SearchText, expectedWildstarFields, expectedTextQueryType).Build(_queryContainerDescriptor), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CreateGeneratesCorrectQueryWhenUsingExactQuery(string searchText)
+        {
+            // Arrange
+            _request.SearchText = searchText;
+
+            var expectedExactQueryFields = new List<string>()
+            {
+                "tenuredAsset.uprn"
+            };
+
+            var expectedTextQueryType = TextQueryType.MostFields;
+
+            _queryBuilderMock.Setup(x =>
+                x.WithExactQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<IExactSearchQuerystringProcessor>(), It.IsAny<TextQueryType>())
+                .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>()));
+
+            // Act
+            _ = _sut.Create(_request, _queryContainerDescriptor);
+
+            // Assert
+            _queryBuilderMock.Verify(x =>
+                x.WithExactQuery(_request.Uprn, expectedExactQueryFields, null, expectedTextQueryType)
+                .Build(_queryContainerDescriptor), Times.Once);
+        }
+    }
+}

--- a/HousingSearchApi.Tests/V1/Factories/TenureQueryGeneratorTests.cs
+++ b/HousingSearchApi.Tests/V1/Factories/TenureQueryGeneratorTests.cs
@@ -149,6 +149,12 @@ namespace HousingSearchApi.Tests.V1.Factories
 
             var expectedTextQueryType = TextQueryType.MostFields;
 
+            _queryFilterBuilderMock.Setup(x =>
+              x.WithMultipleFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>())
+              .WithFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+              .WithWildstarQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+              .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>()));
+
             _queryBuilderMock.Setup(x =>
                 x.WithExactQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<IExactSearchQuerystringProcessor>(), It.IsAny<TextQueryType>())
                 .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>()));
@@ -160,6 +166,12 @@ namespace HousingSearchApi.Tests.V1.Factories
             _queryBuilderMock.Verify(x =>
                 x.WithExactQuery(_request.Uprn, expectedExactQueryFields, null, expectedTextQueryType)
                 .Build(_queryContainerDescriptor), Times.Once);
+
+            _queryFilterBuilderMock.Verify(x =>
+             x.WithMultipleFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>())
+              .WithFilterQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+              .WithWildstarQuery(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<TextQueryType>())
+              .Build(It.IsAny<QueryContainerDescriptor<QueryableTenure>>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1325](https://hackney.atlassian.net/browse/TS-1325)

## Describe this PR

### *What is the problem we're trying to solve*

`TenureQueryGenerator` doesn't currently have any test coverage.

### *What changes have we introduced*

Add test coverage for the `TenureQueryGenerator` to cover the functionality changes introduced in [PR#221](https://github.com/LBHackney-IT/housing-search-api/pull/221).  Also add coverage for the existing functionality.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1325]: https://hackney.atlassian.net/browse/TS-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ