### PR TITLE
TS-1441 add last hit id support for tenures

### DIFF
--- a/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -1,7 +1,9 @@
+using FluentAssertions;
 using FluentValidation.TestHelper;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Boundary.Requests.Validation;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
@@ -39,6 +41,25 @@ namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
             result.ShouldHaveValidationErrorFor(x => x.LastHitTenureStartDate);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ShouldErrorWhenLastHitTenureStartDateIsProvidedButLastHitIdIsNullOrEmpty(string lastHitId)
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitTenureStartDate = "1234567",
+                LastHitId = lastHitId
+            };
+
+            var expectedErrorMessage = "LastHitId must be provided with LastHitTenureStartDate";
+
+            var result = _classUnderTest.TestValidate(query);
+
+            result.ShouldHaveValidationErrorFor(x => x.LastHitId);
+            result.Errors.Single().ErrorMessage.Should().Be(expectedErrorMessage);
+        }
+
         [Fact]
         public void ShouldNotErrorWhenLastHitTenureStartDateIsInMillisecondsFormat()
         {
@@ -62,5 +83,6 @@ namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
             var result = _classUnderTest.TestValidate(query);
             result.ShouldNotHaveValidationErrorFor(x => x.LastHitTenureStartDate);
         }
+
     }
 }

--- a/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -84,5 +84,40 @@ namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
             result.ShouldNotHaveValidationErrorFor(x => x.LastHitTenureStartDate);
         }
 
+        [Fact]
+        public void ShouldErrorWhenLastHitIdLooksDangerous()
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitId = "<string"
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.LastHitId);
+        }
+
+        [Fact]
+        public void ShouldErrorWhenLastHitIdIsNotInAValidGuidFormat()
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitId = "random_string"
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.LastHitId);
+        }
+
+        [Fact]
+        public void ShouldNotErrorWhenLastHitIdIsInValidGuidFormat()
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitId = Guid.NewGuid().ToString()
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldNotHaveValidationErrorFor(x => x.LastHitId);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi.Tests/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -1,0 +1,66 @@
+using FluentValidation.TestHelper;
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Requests.Validation;
+using System;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.Boundary.Requests.Validation
+{
+    public class GetAllTenureListRequestValidatorTests
+    {
+        private readonly GetAllTenureListRequestValidator _classUnderTest;
+
+        public GetAllTenureListRequestValidatorTests()
+        {
+            _classUnderTest = new GetAllTenureListRequestValidator();
+        }
+
+        [Fact]
+        public void ShouldErrorWhenLastHitTenureStartDateIsNotInMillisecondsFormat()
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitTenureStartDate = DateTime.Now.ToString()
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.LastHitTenureStartDate);
+        }
+
+        [Fact]
+        public void ShouldErrorWhenLastHitTenureStartDateStringLooksDangerous()
+        {
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitTenureStartDate = "<string"
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldHaveValidationErrorFor(x => x.LastHitTenureStartDate);
+        }
+
+        [Fact]
+        public void ShouldNotErrorWhenLastHitTenureStartDateIsInMillisecondsFormat()
+        {
+            DateTime dt = DateTime.Now.AddDays(-10);
+            var startDateInMillisecondsSinceEpoch = (long) dt.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+
+            var query = new GetAllTenureListRequest()
+            {
+                LastHitTenureStartDate = startDateInMillisecondsSinceEpoch.ToString()
+            };
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldNotHaveValidationErrorFor(x => x.LastHitTenureStartDate);
+        }
+
+        [Fact]
+        public void ShoulNotErrorWhenLastHitTenureStartDateIsNotProvided()
+        {
+            var query = new GetAllTenureListRequest();
+
+            var result = _classUnderTest.TestValidate(query);
+            result.ShouldNotHaveValidationErrorFor(x => x.LastHitTenureStartDate);
+        }
+    }
+}

--- a/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
+++ b/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
@@ -106,6 +106,7 @@ namespace HousingSearchApi.Tests.V1.Controllers
         {
             // given
             _getAllTenureListResponse.LastHitId = null;
+            _getAllTenureListResponse.LastHitTenureStartDate = null;
 
             _mockGetTenureListSetsUseCase
                 .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))

--- a/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
+++ b/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
@@ -105,6 +105,8 @@ namespace HousingSearchApi.Tests.V1.Controllers
         public async Task GetAllTenureList_WhenUseCaseReturnsResultsIncludesThemInTheResponseObject()
         {
             // given
+            _getAllTenureListResponse.LastHitId = null;
+
             _mockGetTenureListSetsUseCase
                 .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))
                 .ReturnsAsync(_getAllTenureListResponse);
@@ -151,7 +153,7 @@ namespace HousingSearchApi.Tests.V1.Controllers
             // given
             var expectedLastHitId = _getAllTenureListResponse.Tenures.Last().Id;
 
-            _getAllTenureListResponse.SetLastHitId(expectedLastHitId);
+            _getAllTenureListResponse.LastHitId = expectedLastHitId;
 
             _mockGetTenureListSetsUseCase
                 .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))
@@ -172,7 +174,7 @@ namespace HousingSearchApi.Tests.V1.Controllers
             // given
             var expectedLastHitTenureStartDate = "12345678";
 
-            _getAllTenureListResponse.SetLastHitTenureStartDate(expectedLastHitTenureStartDate);
+            _getAllTenureListResponse.LastHitTenureStartDate = expectedLastHitTenureStartDate;
 
             _mockGetTenureListSetsUseCase
                 .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))

--- a/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
+++ b/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
@@ -44,7 +44,9 @@ namespace HousingSearchApi.Tests.V1.Controllers
             // given
             var request = new GetTenureListRequest();
             var response = new GetTenureListResponse();
-            _mockGetTenureListUseCase.Setup(x => x.ExecuteAsync(request)).ReturnsAsync(response);
+            _mockGetTenureListUseCase
+                .Setup(x => x.ExecuteAsync(request))
+                .ReturnsAsync(response);
 
             // when
             await _classUnderTest.GetTenureList(request).ConfigureAwait(false);
@@ -58,7 +60,9 @@ namespace HousingSearchApi.Tests.V1.Controllers
         public async Task GetAllTenureList_CallsGetTenureListSetsUseCase()
         {
             // given
-            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+            _mockGetTenureListSetsUseCase
+                .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))
+                .ReturnsAsync(_getAllTenureListResponse);
 
             // when
             await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
@@ -71,7 +75,9 @@ namespace HousingSearchApi.Tests.V1.Controllers
         public async Task GetAllTenureList_CallsGetTenureListSetsUseCaseWithGivenGetAllTenureListRequest()
         {
             // given
-            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(_getAllTenureListRequest)).ReturnsAsync(_getAllTenureListResponse);
+            _mockGetTenureListSetsUseCase
+                .Setup(x => x.ExecuteAsync(_getAllTenureListRequest))
+                .ReturnsAsync(_getAllTenureListResponse);
 
             // when
             await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
@@ -84,7 +90,9 @@ namespace HousingSearchApi.Tests.V1.Controllers
         public async Task GetAllTenureList_WhenUseCaseCallIsSuccessfulReturnsOkObjectResult()
         {
             // given
-            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+            _mockGetTenureListSetsUseCase
+                .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()))
+                .ReturnsAsync(_getAllTenureListResponse);
 
             // when
             var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
@@ -121,7 +129,7 @@ namespace HousingSearchApi.Tests.V1.Controllers
             // given
             var expectedTenuresCount = _getAllTenureListResponse.Tenures.Count;
 
-            //this is normally set by the search gateway
+            //this is normally set by the search gateway, so we can set it here
             _getAllTenureListResponse.SetTotal(expectedTenuresCount);
 
             _mockGetTenureListSetsUseCase
@@ -132,6 +140,7 @@ namespace HousingSearchApi.Tests.V1.Controllers
             var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
             var okResult = result as OkObjectResult;
             var okResultvalue = (APIAllTenureResponse<GetAllTenureListResponse>) okResult.Value;
+
             // then
             okResultvalue.Total.Should().Be(expectedTenuresCount);
         }

--- a/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
+++ b/HousingSearchApi.Tests/V1/Controllers/GetTenureListControllerTests.cs
@@ -1,8 +1,15 @@
+using AutoFixture;
+using FluentAssertions;
+using Hackney.Core.Logging;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Boundary.Responses;
+using HousingSearchApi.V1.Boundary.Responses.Metadata;
 using HousingSearchApi.V1.Controllers;
 using HousingSearchApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,15 +19,23 @@ namespace HousingSearchApi.Tests.V1.Controllers
     public class GetTenureListControllerTests
     {
         private readonly Mock<IGetTenureListUseCase> _mockGetTenureListUseCase;
+        private readonly Mock<IGetTenureListSetsUseCase> _mockGetTenureListSetsUseCase;
         private readonly GetTenureListController _classUnderTest;
-
+        private readonly GetAllTenureListRequest _getAllTenureListRequest;
+        private readonly GetAllTenureListResponse _getAllTenureListResponse;
+        private readonly Fixture _fixture;
 
         public GetTenureListControllerTests()
         {
             new LogCallAspectFixture().RunBeforeTests();
 
             _mockGetTenureListUseCase = new Mock<IGetTenureListUseCase>();
-            _classUnderTest = new GetTenureListController(_mockGetTenureListUseCase.Object);
+            _mockGetTenureListSetsUseCase = new Mock<IGetTenureListSetsUseCase>();
+            _classUnderTest = new GetTenureListController(_mockGetTenureListUseCase.Object, _mockGetTenureListSetsUseCase.Object);
+
+            _fixture = new Fixture();
+            _getAllTenureListRequest = _fixture.Create<GetAllTenureListRequest>();
+            _getAllTenureListResponse = _fixture.Create<GetAllTenureListResponse>();
         }
 
         [Fact]
@@ -37,5 +52,192 @@ namespace HousingSearchApi.Tests.V1.Controllers
             // then
             _mockGetTenureListUseCase.Verify(x => x.ExecuteAsync(request), Times.Once);
         }
+
+        //all tenures
+        [Fact]
+        public async Task GetAllTenureList_CallsGetTenureListSetsUseCase()
+        {
+            // given
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+
+            // when
+            await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            //then
+            _mockGetTenureListSetsUseCase.Verify(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_CallsGetTenureListSetsUseCaseWithGivenGetAllTenureListRequest()
+        {
+            // given
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(_getAllTenureListRequest)).ReturnsAsync(_getAllTenureListResponse);
+
+            // when
+            await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            // then
+            _mockGetTenureListSetsUseCase.Verify(x => x.ExecuteAsync(_getAllTenureListRequest), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_WhenUseCaseCallIsSuccessfulReturnsOkObjectResult()
+        {
+            // given
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+
+            // when
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            // then
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_WhenUseCaseReturnsResultsIncludesThemInTheResponseObject()
+        {
+            // given
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+
+            // when
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            // then
+            var expectedResults = new APIResponse<GetAllTenureListResponse>()
+            {
+                Results = _getAllTenureListResponse
+            };
+
+            var expectedResponse = new OkObjectResult(expectedResults);
+
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_WhenUseCaseReturnsResultsAddsCorrectTotalToResponse()
+        {
+            // given
+            var expectedTenuresCount = _getAllTenureListResponse.Tenures.Count;
+
+            //this is normally set by the search gateway
+            _getAllTenureListResponse.SetTotal(expectedTenuresCount);
+
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+
+            var expectedResults = new APIResponse<GetAllTenureListResponse>()
+            {
+                Results = _getAllTenureListResponse,
+                Total = expectedTenuresCount
+            };
+
+            // when
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+            var okResult = result as OkObjectResult;
+
+            // then
+            okResult.Value.Should().BeEquivalentTo(expectedResults);
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_WhenUseCaseReturnsResultsAddsCorrectLastHitIdToResponse()
+        {
+            // given
+            // lastHitId is set by the search gateway
+            // Use case returns the GetAllTenureListResponse response from the gateway as is, so we can set it here
+            _mockGetTenureListSetsUseCase.Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ReturnsAsync(_getAllTenureListResponse);
+
+            // when
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+            var okResult = result as OkObjectResult;
+
+            // then
+            var resultValues = okResult.Value as APIAllResponse<GetAllTenureListResponse>;
+
+            resultValues.LastHitId.Should().Be(_getAllTenureListResponse.LastHitId);
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_ReturnsBadRequestObjectResultWhenUseCaseThrowsAnException()
+        {
+            // given
+            var ex = new Exception();
+
+            // when
+            _mockGetTenureListSetsUseCase
+                .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ThrowsAsync(ex);
+
+            // then
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Fact]
+        public async Task GetAllTenureList_ReturnsBadRequestObjectResultWithExceptionMessageWhenUseCaseThrowsAnException()
+        {
+            // given
+            var exceptionMessage = "test exception message";
+            var ex = new Exception(exceptionMessage);
+
+            // when
+            _mockGetTenureListSetsUseCase
+                .Setup(x => x.ExecuteAsync(It.IsAny<GetAllTenureListRequest>())).ThrowsAsync(ex);
+
+            // then
+            var result = await _classUnderTest.GetAllTenureList(_getAllTenureListRequest).ConfigureAwait(false);
+
+            var badRequestObjectResult = result as BadRequestObjectResult;
+            badRequestObjectResult.Value.Should().Be(exceptionMessage);
+        }
+
+        [Fact]
+        public void GetAllTenureList_IsDecoratedWithCorrectAttributes()
+        {
+            // given
+            var controllerType = _classUnderTest.GetType();
+            var methodInfo = controllerType.GetMethod("GetAllTenureList");
+            var methodAttributes = methodInfo.GetCustomAttributes(false);
+
+            // then
+
+            // [HttpGet, MapToApiVersion("1")]
+            var apiVersionAttribute = methodAttributes
+                .Where(x => x.GetType() == typeof(MapToApiVersionAttribute)).Select(x => x as MapToApiVersionAttribute).ToList();
+
+            apiVersionAttribute.Count.Should().Be(1);
+            apiVersionAttribute.First().Versions.First().MajorVersion.Should().Be(1);
+            apiVersionAttribute.First().Versions.First().MinorVersion.Should().BeNull();
+
+            // [LogCall(Microsoft.Extensions.Logging.LogLevel.Information)]
+            var logCallAttributes = methodAttributes
+                .Where(x => x.GetType() == typeof(LogCallAttribute)).Select(x => x as LogCallAttribute).ToList();
+
+            logCallAttributes.Count.Should().Be(1);
+            logCallAttributes.First().Level.Should().Be(Microsoft.Extensions.Logging.LogLevel.Information);
+
+            // responses
+            var producesResponseTypeAttributes = methodAttributes
+                .Where(x => x.GetType() == typeof(ProducesResponseTypeAttribute)).Select(x => x as ProducesResponseTypeAttribute).ToList();
+
+            producesResponseTypeAttributes.Count.Should().Be(2);
+
+            // 200 response
+            var okResponseAttribute = producesResponseTypeAttributes.First(x => x.StatusCode == 200).Type;
+            var expectedOkResponseTypeFullName = typeof(APIAllResponse<GetAllTenureListResponse>).FullName;
+            okResponseAttribute.FullName.Should().Be(expectedOkResponseTypeFullName);
+
+            // 400 response
+            var badRequestObjectResultAttribute = producesResponseTypeAttributes.First(x => x.StatusCode == 400).Type;
+            var expectedBadRequestObjectResultFullName = typeof(APIAllResponse<BadRequestObjectResult>).FullName;
+            badRequestObjectResultAttribute.FullName.Should().Be(expectedBadRequestObjectResultFullName);
+
+            // route
+            var routeAttributes = methodAttributes
+                .Where(x => x.GetType() == typeof(RouteAttribute)).Select(x => x as RouteAttribute).ToList();
+
+            routeAttributes.Count().Should().Be(1);
+            routeAttributes.Any(x => x.Template.ToString() == "all").Should().BeTrue();
+        }
     }
 }
+

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -169,5 +169,34 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         {
             //nothing to do here, we already have existing records created by GivenATenureIndexExists fixture
         }
+
+        public void GivenTenuresWithSpecificContentExist(string oldestRecord, string middleRecord, string latestRecord)
+        {
+            var listOfTenures = new List<QueryableTenure>();
+
+            var latestTenure = QueryableTenureHelper.CreateQueyableTenure();
+            latestTenure.StartOfTenureDate = "2024-05-28T15:08:09Z";
+            latestTenure.PaymentReference = "veryspecificpaymentreferencefortestinglasthitidone";
+            latestTenure.Id = latestRecord;
+            listOfTenures.Add(latestTenure);
+
+            var middleTenure = QueryableTenureHelper.CreateQueyableTenure();
+            middleTenure.StartOfTenureDate = "2024-05-27T15:08:09Z";
+            middleTenure.PaymentReference = "veryspecificpaymentreferencefortestinglasthitidtwo";
+            middleTenure.Id = middleRecord;
+            listOfTenures.Add(middleTenure);
+
+            var oldestTenure = QueryableTenureHelper.CreateQueyableTenure();
+            oldestTenure.StartOfTenureDate = "2024-05-26T15:08:09Z";
+            oldestTenure.PaymentReference = "veryspecificpaymentreferencefortestinglasthitidthree";
+            oldestTenure.Id = oldestRecord;
+            listOfTenures.Add(oldestTenure);
+
+            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+
+            while (!awaitable.GetAwaiter().IsCompleted) { }
+
+            Thread.Sleep(10000);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureAllSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureAllSteps.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using HousingSearchApi.Tests.V1.E2ETests.Steps.Base;
+using HousingSearchApi.V1.Boundary.Responses;
+using HousingSearchApi.V1.Boundary.Responses.Metadata;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace HousingSearchApi.Tests.V1.E2ETests.Steps
+{
+    public class GetTenureAllSteps : BaseSteps
+    {
+        public GetTenureAllSteps(HttpClient httpclient) : base(httpclient)
+        {
+        }
+
+        // when
+        public async Task WhenTenuresAllRequestDoesNotContainSearchString()
+        {
+            var uri = new Uri("api/v1/search/tenures/all", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        public async Task WhenTenuresAllRequestContainSearchString()
+        {
+            var uri = new Uri("api/v1/search/tenures/all?searchText=abc", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenAPageSizeIsProvidedForTenuresAll(int pageSize)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText=abc&&pageSize={pageSize}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForASpecificTenureUsingTenuresAll(string paymentReference, string fullAddress, string fullName)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText={paymentReference}%20{fullAddress}%20{fullName}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenTenuresAllRequestContainsUprn(string uprn)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?uprn={uprn}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForAllTaTenuresUsingTenuresAll()
+        {
+            var uri = new Uri("api/v1/search/tenures/all?searchText=\"\"&isTemporaryAccommodation=true", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForTaTenuresUsingTenuresAllWithABookingStatusAndNoSearchText(string bookingStatus)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?bookingStatus={bookingStatus}&searchText=\"\"&isTemporaryAccommodation=true", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForASpecificTaTenureByTenantFullNameUsingTenuresAll(string fullName)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText={fullName}&isTemporaryAccommodation=true", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForASpecificTaTenureByBookingStatusAndTenantFullNameUsingTenuresAll(string bookingStatus, string fullName)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?bookingStatus={bookingStatus}&searchText={fullName}&isTemporaryAccommodation=true", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+        public async Task WhenSearchingForTenuresWithSortingByTenureStartDateUsingTenuresAll(bool isDesc)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText=%22%22&sortBy=tenureStartDate&isDesc={isDesc}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        public async Task WhenSearchingForTenuresUsingTenuresAll()
+        {
+            var uri = new Uri("api/v1/search/tenures/all?searchText=%22%22", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        public async Task WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeUsingTenuresAll(int pageSize, bool isDesc)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText=veryspecificpaymentreferencefortestinglasthitid&sortBy=tenureStartDate&isDesc={isDesc}&pageSize={pageSize}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        public async Task WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeAndLastHitIdAndLastHitTenureStartDateUsingTenuresAll(int pageSize, string lastHitId, string lastHitTenureStartDate, bool isDesc)
+        {
+            var uri = new Uri($"api/v1/search/tenures/all?searchText=veryspecificpaymentreferencefortestinglasthitid&sortBy=tenureStartDate&isDesc={isDesc}&pageSize={pageSize}&lastHitId={lastHitId}&lastHitTenureStartDate={lastHitTenureStartDate}", UriKind.Relative);
+            _lastResponse = await _httpClient.GetAsync(uri).ConfigureAwait(false);
+        }
+
+        // then
+        public async Task ThenTheReturningAllTenureResultsShouldBeOfThatSize(int pageSize)
+        {
+            var result = await DeserializeResults();
+
+            result.Results.Tenures.Count.Should().Be(pageSize);
+        }
+
+        public async Task ThenTheFirstOfTheReturningTenureAllResultsShouldBeTheMostRelevantOne(string paymentReference, string fullAddress, string fullName)
+        {
+            var result = await DeserializeResults();
+
+            result.Results.Tenures.First().PaymentReference.Should().Be(paymentReference);
+            result.Results.Tenures.First().TenuredAsset.FullAddress.Should().Be(fullAddress);
+            result.Results.Tenures.First().HouseholdMembers.First().FullName.Should().Be(fullName);
+        }
+
+        public async Task ThenTheReturningTenureAllResultShouldBeTheSpecificTenure(string uprn, int tenureCount)
+        {
+            var result = await DeserializeResults();
+
+            result.Results.Tenures.Count.Should().Be(tenureCount);
+            result.Results.Tenures.First().TenuredAsset.Uprn.Should().Be(uprn);
+        }
+
+        public async Task ThenTheReturningTenureAllResultsShouldIncludeAllTaTenures(int amountOfTaTenures)
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+            tenures.Count.Should().Be(amountOfTaTenures);
+            foreach (var tenure in tenures)
+            {
+                tenure.TenuredAsset.IsTemporaryAccommodation.Should().Be(true);
+            }
+        }
+
+        public async Task ThenTheReturningTenureAllResultsShouldBeTheFilteredTaTenures(string bookingStatus, int tenureCount)
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+            tenures.Count.Should().Be(tenureCount);
+            foreach (var tenure in tenures)
+            {
+                tenure.TempAccommodationInfo.BookingStatus.Should().Be(bookingStatus);
+            }
+        }
+
+        public async Task ThenTheReturningTenureAllResultsShouldBeTheSearchedTaTenures(string fullName, int tenureCount)
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+            tenures.Count.Should().Be(tenureCount);
+            foreach (var tenure in tenures)
+            {
+                tenure.HouseholdMembers.First().FullName.Should().Be(fullName);
+            }
+        }
+
+        public async Task ThenTheReturningTenureALlResultShouldHaveTheSpecificTaTenure(string bookingStatus, string fullName, int tenureCount)
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+            tenures.Count.Should().Be(tenureCount);
+            tenures.First().TempAccommodationInfo.BookingStatus.Should().Be(bookingStatus);
+            tenures.First().HouseholdMembers.First().FullName.Should().Be(fullName);
+        }
+
+        public async Task ThenTheReturningTenureAllResultsShouldBeSortedByDescendingTenureStartDate()
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+
+            CollectionAssert.AreEqual(tenures.OrderByDescending(x => x.StartOfTenureDate), tenures);
+        }
+
+        public async Task ThenTheReturningTenureAllResultsShouldBeSortedByAscendingTenureStartDate()
+        {
+            var result = await DeserializeResults();
+
+            var tenures = result.Results.Tenures;
+
+            CollectionAssert.AreEqual(tenures.OrderBy(x => x.StartOfTenureDate), tenures);
+        }
+
+        public async Task ThenTheReturningTenureAllResultsContainTotalValueOtherThanZero()
+        {
+            var result = await DeserializeResults();
+
+            result.Total.Should().NotBe(0);
+        }
+
+        public async Task ThenTheReturningTenureAllResultsContainCorrectRecordsInCorrectOrder(string firstId, string lastId, int expectedCount)
+        {
+            var result = await DeserializeResults();
+
+            //see test setup for specific record
+            result.Results.Tenures.Count.Should().Be(expectedCount);
+            result.Results.Tenures.First().Id.Should().Be(firstId);
+            result.Results.Tenures.Last().Id.Should().Be(lastId);
+        }
+
+        public async Task ThenReturningTenureAllResultsContainSingleCorrectTenure(string idToMatch)
+        {
+            var result = await DeserializeResults();
+
+            result.Results.Tenures.Count.Should().Be(1);
+            result.Results.Tenures.First().Id.Should().Be(idToMatch);
+        }
+
+        private async Task<APIAllResponse<GetAllTenureListResponse>> DeserializeResults()
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllTenureListResponse>>(resultBody, _jsonOptions);
+
+            return result;
+        }
+    }
+}

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetTenureSteps.cs
@@ -170,5 +170,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             CollectionAssert.AreEqual(tenures.OrderBy(x => x.StartOfTenureDate), tenures);
         }
+        public async Task ThenTheReturningTenureAllResultsShouldBeSortedByAscendingTenureStartDate()
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIResponse<GetTenureListResponse>>(resultBody, _jsonOptions);
+
+            var tenures = result.Results.Tenures;
+
+            CollectionAssert.AreEqual(tenures.OrderBy(x => x.StartOfTenureDate), tenures);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAllTenuresStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAllTenuresStories.cs
@@ -1,0 +1,223 @@
+using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
+using HousingSearchApi.Tests.V1.E2ETests.Steps;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.E2ETests.Stories
+{
+    [Story(
+        AsA = "Service",
+        IWant = "The Tenure Search All Endpoint to return results",
+        SoThat = "it is possible to search for tenures")]
+    [Collection("ElasticSearch collection")]
+    public class GetAllTenuresStories
+    {
+        private readonly MockWebApplicationFactory<Startup> _factory;
+        private readonly TenureFixture _tenureFixture;
+        private readonly GetTenureAllSteps _steps;
+
+        public GetAllTenuresStories(MockWebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+            var httpClient = factory.CreateClient();
+            var elasticClient = factory.ElasticSearchClient;
+
+            _steps = new GetTenureAllSteps(httpClient);
+            _tenureFixture = new TenureFixture(elasticClient, httpClient);
+        }
+
+        //if search text and uprn are empty TenureQueryGenerator throws an exception that results in bad rquest
+        [Fact]
+        public void ServiceReturnsBadRequestResult()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .When(w => _steps.WhenTenuresAllRequestDoesNotContainSearchString())
+                .Then(t => _steps.ThenTheLastRequestShouldBeBadRequestResult(default))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsOkResult()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .When(w => _steps.WhenTenuresAllRequestContainSearchString())
+                .Then(t => _steps.ThenTheLastRequestShouldBe200())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsCorrectPageSize()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .When(w => _steps.WhenAPageSizeIsProvidedForTenuresAll(5))
+                .Then(t => _steps.ThenTheReturningAllTenureResultsShouldBeOfThatSize(5))
+                .BDDfy();
+        }
+
+        //deserializing to APIResponse here  
+        [Fact]
+        public void ServiceReturnsMostRelevantResultFirst()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenSimilarTenures("FirstEntry", "SecondEntry", "ThirdEntry"))
+                .When(w => _steps.WhenSearchingForASpecificTenureUsingTenuresAll("FirstEntry", "SecondEntry", "ThirdEntry"))
+                .Then(t => _steps.ThenTheFirstOfTheReturningTenureAllResultsShouldBeTheMostRelevantOne("FirstEntry", "SecondEntry", "ThirdEntry"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnSpecificTenureByUprn()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenATenureWithSpecificUprn("12345678"))
+                .When(w => _steps.WhenTenuresAllRequestContainsUprn("12345678"))
+                .Then(t => _steps.ThenTheReturningTenureAllResultShouldBeTheSpecificTenure("12345678", 1))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsAllTaTenures()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .When(w => _steps.WhenSearchingForAllTaTenuresUsingTenuresAll())
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldIncludeAllTaTenures(5))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsFilteredByBookingStatusTaTenures()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForTaTenuresUsingTenuresAllWithABookingStatusAndNoSearchText("ACC"))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldBeTheFilteredTaTenures("ACC", 2))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsTaTenuresWhenSearchedByNameButNotFilteredByBookingStatus()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForASpecificTaTenureByTenantFullNameUsingTenuresAll("John Doe"))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldBeTheSearchedTaTenures("John Doe", 2))
+                .BDDfy();
+        }
+
+        //TODO: use random names
+        [Fact]
+        public void ServiceReturnsSpecificTenuresWhenSearchedByNameAndFilteredByBookingStatus()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTaTenuresExist(5))
+                .Given(g => _tenureFixture.GivenSimilarTaTenuresExist("ACC", "John Doe"))
+                .When(w => _steps.WhenSearchingForASpecificTaTenureByBookingStatusAndTenantFullNameUsingTenuresAll("ACC", "John Doe"))
+                .Then(t => _steps.ThenTheReturningTenureALlResultShouldHaveTheSpecificTaTenure("ACC", "John Doe", 1))
+                .BDDfy();
+
+        }
+
+        [Fact]
+        public void ServiceReturnsLatestTenuresFirstWhenSortingByTenureStartDateIsSetToDesc()
+        {
+            var isDesc = true;
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithDifferentStartDatesExist())
+                .When(w => _steps.WhenSearchingForTenuresWithSortingByTenureStartDateUsingTenuresAll(isDesc))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldBeSortedByDescendingTenureStartDate())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsLatestTenuresLastWhenSortingByTenureStartDateIsSetToAsc()
+        {
+            var isDesc = false;
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithDifferentStartDatesExist())
+                .When(w => _steps.WhenSearchingForTenuresWithSortingByTenureStartDateUsingTenuresAll(isDesc))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldBeSortedByAscendingTenureStartDate())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsTotalInTheResponse()
+        {
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .When(w => _steps.WhenSearchingForTenuresUsingTenuresAll())
+                .Then(t => _steps.ThenTheReturningTenureAllResultsContainTotalValueOtherThanZero())
+                .BDDfy();
+        }
+
+        //last hit id tests require items with known IDs, start dates and content
+        [Fact]
+        public void ServiceReturnsFirstSetOfResultsWhenLastHitIdIsNotSetInTheRequestWhilePageSizeAndSortingByTenureStartDateToDescendingAreSet()
+        {
+
+            var oldestRecord = "caec45d1-8034-419b-bc55-ff491079b628";
+            var middleRecord = "ecbf9d02-3b1c-4e9f-92ab-0ddb74b80b27";
+            var latestRecord = "a04d59de-1f2c-4cca-ab20-cb501347e226";
+            var isDesc = true;
+            var pageSize = 2;
+
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithSpecificContentExist(oldestRecord, middleRecord, latestRecord))
+                .When(w => _steps.WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeUsingTenuresAll(pageSize, isDesc))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsContainCorrectRecordsInCorrectOrder(latestRecord, middleRecord, pageSize))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsFirstSetOfResultsWhenLastHitIdIsInTheRequestWhilePageSizeAndSortingByTenureStartDateToDescendingAreSet()
+        {
+            var oldestRecord = "caec45d1-8034-419b-bc55-ff491079b690";
+            var middleRecord = "ecbf9d02-3b1c-4e9f-92ab-0ddb74b80b46";
+            var latestRecord = "a04d59de-1f2c-4cca-ab20-cb501347e2bb";
+            var middleRecordTenureStartDateInMillisecondsSinceEpoch = "1716822489000"; //"2024-05-27T15:08:09Z", set in the firstItemOnTheSecondSet 
+            var isDesc = true;
+            var pageSize = 2;
+
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithSpecificContentExist(oldestRecord, middleRecord, latestRecord))
+                .When(w => _steps.WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeAndLastHitIdAndLastHitTenureStartDateUsingTenuresAll(pageSize, middleRecord, middleRecordTenureStartDateInMillisecondsSinceEpoch, isDesc))
+                .Then(t => _steps.ThenReturningTenureAllResultsContainSingleCorrectTenure(oldestRecord))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsFirstSetOfResultsWhenLastHitIdIsNotSetInTheRequestWhilePageSizeAndSortingByTenureStartDateToAscendingAreSet()
+        {
+            var oldestRecord = "caec45d1-8034-419b-bc55-ff491079b628";
+            var middleRecord = "ecbf9d02-3b1c-4e9f-92ab-0ddb74b80b27";
+            var latestRecord = "a04d59de-1f2c-4cca-ab20-cb501347e226";
+            var isDesc = false;
+            var pageSize = 2;
+
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithSpecificContentExist(oldestRecord, middleRecord, latestRecord))
+                .When(w => _steps.WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeUsingTenuresAll(pageSize, isDesc))
+                .Then(t => _steps.ThenTheReturningTenureAllResultsContainCorrectRecordsInCorrectOrder(oldestRecord, middleRecord, pageSize))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsFirstSetOfResultsWhenLastHitIdIsInTheRequestWhilePageSizeAndSortingByTenureStartDateToAscendingAreSet()
+        {
+            var oldestRecord = "caec45d1-8034-419b-bc55-ff491079b690";
+            var middleRecord = "ecbf9d02-3b1c-4e9f-92ab-0ddb74b80b46";
+            var latestRecord = "a04d59de-1f2c-4cca-ab20-cb501347e2bb";
+            var middleRecordTenureStartDateInMillisecondsSinceEpoch = "1716822489000";
+            var isDesc = false;
+            var pageSize = 2;
+
+            this.Given(g => _tenureFixture.GivenATenureIndexExists())
+                .Given(g => _tenureFixture.GivenTenuresWithSpecificContentExist(oldestRecord, middleRecord, latestRecord))
+                .When(w => _steps.WhenSearchingForTenuresWithSearchTextSortingByTenureStartDateDescAndSettingPageSizeAndLastHitIdAndLastHitTenureStartDateUsingTenuresAll(pageSize, middleRecord, middleRecordTenureStartDateInMillisecondsSinceEpoch, isDesc))
+                .Then(t => _steps.ThenReturningTenureAllResultsContainSingleCorrectTenure(latestRecord))
+                .BDDfy();
+        }
+    }
+}
+

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAllTenuresStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAllTenuresStories.cs
@@ -107,7 +107,6 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
 
-        //TODO: use random names
         [Fact]
         public void ServiceReturnsSpecificTenuresWhenSearchedByNameAndFilteredByBookingStatus()
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetTenureStories.cs
@@ -133,7 +133,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             this.Given(g => _tenureFixture.GivenATenureIndexExists())
                 .Given(g => _tenureFixture.GivenTenuresWithDifferentStartDatesExist())
                 .When(w => _steps.WhenSearchingForTenuresWithSortingByTenureStartDate(false))
-                .Then(t => _steps.ThenTheReturningResultsShouldBeSortedByAscendingTenureStartDate())
+                .Then(t => _steps.ThenTheReturningTenureAllResultsShouldBeSortedByAscendingTenureStartDate())
                 .BDDfy();
         }
 

--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -254,7 +254,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
-            response.LastHitId().Should().Be(lastId);
+            response.LastHitId.Should().Be(lastId);
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
-            response.LastHitId().Should().BeNull();
+            response.LastHitId.Should().BeNull();
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
-            response.LastHitTenureStartDate().Should().Be(tenureStartDateInMillisecondsSinceEpoch);
+            response.LastHitTenureStartDate.Should().Be(tenureStartDateInMillisecondsSinceEpoch);
         }
 
 
@@ -325,7 +325,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
-            response.LastHitTenureStartDate().Should().BeNull();
+            response.LastHitTenureStartDate.Should().BeNull();
         }
 
         [Fact]
@@ -353,7 +353,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
-            response.LastHitTenureStartDate().Should().BeNull();
+            response.LastHitTenureStartDate.Should().BeNull();
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -11,7 +11,9 @@ using HousingSearchApi.V1.Helper.Interfaces;
 using HousingSearchApi.V1.Interfaces;
 using Moq;
 using Nest;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -23,6 +25,8 @@ namespace HousingSearchApi.Tests.V1.Gateways
         private readonly SearchGateway _searchGateway;
         private readonly Mock<IElasticSearchWrapper> _elasticSearchWrapperMock;
         private readonly Mock<ICustomAddressSorter> _customAddressSorterMock;
+        private readonly GetAllTenureListRequest _getAllTenureListRequest;
+        private readonly List<QueryableTenure> _queryableTenureList;
 
         private readonly Fixture _fixture = new Fixture();
 
@@ -37,6 +41,9 @@ namespace HousingSearchApi.Tests.V1.Gateways
                 _elasticSearchWrapperMock.Object,
                 _customAddressSorterMock.Object
             );
+
+            _getAllTenureListRequest = _fixture.Create<GetAllTenureListRequest>();
+            _queryableTenureList = _fixture.CreateMany<QueryableTenure>().ToList();
         }
 
         [Fact]
@@ -133,7 +140,6 @@ namespace HousingSearchApi.Tests.V1.Gateways
             response.Should().BeEquivalentTo(new List<Asset>());
         }
 
-        //tenures
         [Fact]
         public async Task GetListOfTenuresSets_CallsSearchTenuresSets()
         {
@@ -156,37 +162,128 @@ namespace HousingSearchApi.Tests.V1.Gateways
         [Fact]
         public async Task GetListOfTenuresSets_CallsSearchTenuresSetsWithCorrectQuery()
         {
-            var query = _fixture.Create<GetAllTenureListRequest>();
-
             SearchResponse<QueryableTenure> elasticSearchResponse = null;
 
             _elasticSearchWrapperMock
-                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query))
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
                 .ReturnsAsync(elasticSearchResponse);
 
-            var response = await _searchGateway.GetListOfTenuresSets(query);
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
             _elasticSearchWrapperMock
                 .Verify(x =>
-                    x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query)
+                    x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest)
                     , Times.Once);
         }
 
         [Fact]
-        public async Task GetListOfTenuresSets_WhenSearchResponseIsNullReturnsCorrectGetAllTenureListResponse()
+        public async Task GetListOfTenuresSets_WhenSearchResponseIsNullReturnsDefaultGetAllTenureListResponse()
         {
-            var query = _fixture.Create<GetAllTenureListRequest>();
             SearchResponse<QueryableTenure> elasticSearchResponse = null;
 
             _elasticSearchWrapperMock
-                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query))
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
                 .ReturnsAsync(elasticSearchResponse);
 
-            var response = await _searchGateway.GetListOfTenuresSets(query);
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
 
             response.Should().BeOfType<GetAllTenureListResponse>();
+            response.Should().BeEquivalentTo(new GetAllTenureListResponse());
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSearchResponseHasTenuresAddsThemToResults()
+        {
+            var hitMock = new Mock<IHit<QueryableTenure>>();
+            hitMock.Setup(x => x.Id).Returns(Guid.NewGuid().ToString());
+
+            var hits = new List<IHit<QueryableTenure>>
+            {
+                hitMock.Object
+            };
+
+            var searchResponseMock = new Mock<ISearchResponse<QueryableTenure>>();
+            searchResponseMock.Setup(x => x.Documents).Returns(_queryableTenureList);
+            searchResponseMock.Setup(x => x.Hits).Returns(hits);
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
+                .ReturnsAsync(searchResponseMock.Object);
+
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
+
+            response.Tenures.Should().BeEquivalentTo(_queryableTenureList.Select(x => x.Create()));
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSearchResponseHasTenuresSetsTheTotal()
+        {
+            var hitMock = new Mock<IHit<QueryableTenure>>();
+            hitMock.Setup(x => x.Id).Returns(Guid.NewGuid().ToString());
+
+            var hits = new List<IHit<QueryableTenure>>
+            {
+                hitMock.Object
+            };
+
+            var searchResponseMock = new Mock<ISearchResponse<QueryableTenure>>();
+            searchResponseMock.Setup(x => x.Documents).Returns(_queryableTenureList);
+            searchResponseMock.Setup(x => x.Total).Returns(_queryableTenureList.Count);
+            searchResponseMock.Setup(x => x.Hits).Returns(hits);
+
+            _elasticSearchWrapperMock
+             .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
+             .ReturnsAsync(searchResponseMock.Object);
+
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
+
+            response.Total().Should().Be(_queryableTenureList.Count);
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSearchResponseHasTenuresSetsTheLastHitId()
+        {
+            //Record ids matching hits is not relevant here, just that the correct lastHitId is set
+            var firstId = Guid.NewGuid().ToString();
+            var firstHitMock = new Mock<IHit<QueryableTenure>>();
+            firstHitMock.Setup(x => x.Id).Returns(firstId);
+
+            var lastId = Guid.NewGuid().ToString();
+            var lastHitMock = new Mock<IHit<QueryableTenure>>();
+            lastHitMock.Setup(x => x.Id).Returns(lastId);
+
+            var hits = new List<IHit<QueryableTenure>>
+            {
+                firstHitMock.Object,
+                lastHitMock.Object
+            };
+
+            var searchResponseMock = new Mock<ISearchResponse<QueryableTenure>>();
+            searchResponseMock.Setup(x => x.Documents).Returns(_queryableTenureList);
+            searchResponseMock.Setup(x => x.Hits).Returns(hits);
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
+                .ReturnsAsync(searchResponseMock.Object);
+
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
+
+            response.LastHitId.Should().Be(lastId);
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSearchResponseHasNoTenuresTheLastHitIdIsNull()
+        {
+            var searchResponseMock = new Mock<ISearchResponse<QueryableTenure>>();
+            searchResponseMock.Setup(x => x.Documents).Returns(new List<QueryableTenure>());
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_getAllTenureListRequest))
+                .ReturnsAsync(searchResponseMock.Object);
+
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
+
             response.LastHitId.Should().BeNull();
-            response.Tenures.Count.Should().Be(0);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using FluentAssertions;
 using Hackney.Shared.HousingSearch.Domain.Asset;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Boundary.Responses;
 using HousingSearchApi.V1.Factories;
@@ -132,5 +133,60 @@ namespace HousingSearchApi.Tests.V1.Gateways
             response.Should().BeEquivalentTo(new List<Asset>());
         }
 
+        //tenures
+        [Fact]
+        public async Task GetListOfTenuresSets_CallsSearchTenuresSets()
+        {
+            var query = new GetAllTenureListRequest();
+
+            SearchResponse<QueryableTenure> elasticSearchResponse = null;
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query))
+                .ReturnsAsync(elasticSearchResponse);
+
+            var response = await _searchGateway.GetListOfTenuresSets(query);
+
+            _elasticSearchWrapperMock
+                .Verify(x =>
+                    x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(It.IsAny<GetAllTenureListRequest>())
+                    , Times.Once);
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_CallsSearchTenuresSetsWithCorrectQuery()
+        {
+            var query = _fixture.Create<GetAllTenureListRequest>();
+
+            SearchResponse<QueryableTenure> elasticSearchResponse = null;
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query))
+                .ReturnsAsync(elasticSearchResponse);
+
+            var response = await _searchGateway.GetListOfTenuresSets(query);
+
+            _elasticSearchWrapperMock
+                .Verify(x =>
+                    x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query)
+                    , Times.Once);
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSearchResponseIsNullReturnsCorrectGetAllTenureListResponse()
+        {
+            var query = _fixture.Create<GetAllTenureListRequest>();
+            SearchResponse<QueryableTenure> elasticSearchResponse = null;
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query))
+                .ReturnsAsync(elasticSearchResponse);
+
+            var response = await _searchGateway.GetListOfTenuresSets(query);
+
+            response.Should().BeOfType<GetAllTenureListResponse>();
+            response.LastHitId.Should().BeNull();
+            response.Tenures.Count.Should().Be(0);
+        }
     }
 }

--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -216,8 +216,8 @@ namespace HousingSearchApi.Tests.V1.Gateways
             searchResponseMock.Setup(x => x.Hits).Returns(hits);
 
             _elasticSearchWrapperMock
-             .Setup(x => x.SearchTenuresSets(_getAllTenureListRequest))
-             .ReturnsAsync(searchResponseMock.Object);
+                .Setup(x => x.SearchTenuresSets(_getAllTenureListRequest))
+                .ReturnsAsync(searchResponseMock.Object);
 
             var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
             var expectedTotal = _queryableTenureList.Count;

--- a/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
+++ b/HousingSearchApi.Tests/V1/Gateways/SearchGatewayTests.cs
@@ -329,7 +329,7 @@ namespace HousingSearchApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task GetListOfTenuresSets_WhenlastHitInSearchResponseHasNoSortsThenSetsLastHitTenureStartDateToNull()
+        public async Task GetListOfTenuresSets_WhenSortsInSearchResponseIsNullThenSetsLastHitTenureStartDateToNull()
         {
             var hitId = Guid.NewGuid().ToString();
             var document = _fixture.Build<QueryableTenure>().With(x => x.Id, hitId).Create();
@@ -337,6 +337,35 @@ namespace HousingSearchApi.Tests.V1.Gateways
 
             var hitMock = new Mock<IHit<QueryableTenure>>();
             hitMock.Setup(x => x.Id).Returns(hitId);
+
+            var hits = new List<IHit<QueryableTenure>>
+            {
+                hitMock.Object
+            };
+
+            var searchResponsoMock = new Mock<ISearchResponse<QueryableTenure>>();
+            searchResponsoMock.Setup(x => x.Documents).Returns(documents);
+            searchResponsoMock.Setup(x => x.Hits).Returns(hits);
+
+            _elasticSearchWrapperMock
+                .Setup(x => x.SearchTenuresSets(It.IsAny<GetAllTenureListRequest>()))
+                .ReturnsAsync(searchResponsoMock.Object);
+
+            var response = await _searchGateway.GetListOfTenuresSets(_getAllTenureListRequest);
+
+            response.LastHitTenureStartDate.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetListOfTenuresSets_WhenSortsInSearchResponseIsEmptyArrayThenSetsLastHitTenureStartDateToNull()
+        {
+            var hitId = Guid.NewGuid().ToString();
+            var document = _fixture.Build<QueryableTenure>().With(x => x.Id, hitId).Create();
+            var documents = new List<QueryableTenure> { document };
+
+            var hitMock = new Mock<IHit<QueryableTenure>>();
+            hitMock.Setup(x => x.Id).Returns(hitId);
+            hitMock.Setup(x => x.Sorts).Returns(Array.Empty<string>());
 
             var hits = new List<IHit<QueryableTenure>>
             {

--- a/HousingSearchApi.Tests/V1/Infrastructure/ElasticSearchWrapperTests.cs
+++ b/HousingSearchApi.Tests/V1/Infrastructure/ElasticSearchWrapperTests.cs
@@ -1,0 +1,137 @@
+using AutoFixture;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Hackney.Shared.HousingSearch.Gateways.Models.Accounts;
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Infrastructure;
+using HousingSearchApi.V1.Interfaces;
+using HousingSearchApi.V1.Interfaces.Factories;
+using HousingSearchApi.V1.Interfaces.Filtering;
+using HousingSearchApi.V1.Interfaces.Sorting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nest;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace HousingSearchApi.Tests.V1.Infrastructure
+{
+    public class ElasticSearchWrapperTests
+    {
+        private readonly Mock<IElasticClient> _elasticClientMock;
+        private readonly Mock<IQueryFactory> _queryFactoryMock;
+        private readonly Mock<IPagingHelper> _pagingHelperMock;
+        private readonly Mock<ISortFactory> _sorfactoryMock;
+        private readonly Mock<IFilterFactory> _filterFactoryMock;
+        private readonly Mock<IIndexSelector> _indexSelectorMock;
+        private readonly Mock<ILogger<ElasticSearchWrapper>> _loggerMock;
+        private readonly ElasticSearchWrapper _elasticSearchWrapper;
+        private readonly GetAllTenureListRequest _request;
+        private readonly Fixture _fixture;
+
+        public ElasticSearchWrapperTests()
+        {
+            _elasticClientMock = new Mock<IElasticClient>();
+            _queryFactoryMock = new Mock<IQueryFactory>();
+            _pagingHelperMock = new Mock<IPagingHelper>();
+            _sorfactoryMock = new Mock<ISortFactory>();
+            _loggerMock = new Mock<ILogger<ElasticSearchWrapper>>();
+            _indexSelectorMock = new Mock<IIndexSelector>();
+            _filterFactoryMock = new Mock<IFilterFactory>();
+
+            _elasticSearchWrapper = new ElasticSearchWrapper(
+                _elasticClientMock.Object,
+                _queryFactoryMock.Object,
+                _pagingHelperMock.Object,
+                _sorfactoryMock.Object,
+                _loggerMock.Object,
+                _indexSelectorMock.Object,
+                _filterFactoryMock.Object);
+
+            _fixture = new Fixture();
+
+            _request = _fixture.Create<GetAllTenureListRequest>();
+
+            //add connection settings
+            var nodes = _fixture.CreateMany<Node>().GetEnumerator();
+
+            _elasticClientMock.Setup(x =>
+                x.ConnectionSettings.ConnectionPool.Nodes.GetEnumerator()).Returns(nodes);
+        }
+
+        [Fact]
+        public async Task SearchTenuresSets_ResultsTypeIsQueryableTenureAndQueryTypeIsGetAllTenureListRequest()
+        {
+            _ = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_request);
+        }
+
+        [Fact]
+        public async Task SearchTenuresSets_CallsESClientToGetNodeUrisFromConnectionSettings()
+        {
+            var result = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_request);
+
+            _elasticClientMock.Verify(x =>
+                x.ConnectionSettings.ConnectionPool.Nodes.GetEnumerator(), Times.Once());
+        }
+
+        [Fact]
+        public async Task SearchTenuresSets_CallsLoggerToLogESnodesUsedAsDebugInfo()
+        {
+            var nodes = _fixture.CreateMany<Node>();
+
+            var uris = string.Join(';', nodes.Select(x => x.Uri));
+
+            var expectedLogMessage = $"ElasticSearch Search Sets begins {uris}";
+
+            _elasticClientMock.Setup(x =>
+                x.ConnectionSettings.ConnectionPool.Nodes.GetEnumerator()).Returns(nodes.GetEnumerator());
+
+            var result = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_request);
+
+            _loggerMock.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Debug),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == expectedLogMessage && @type.Name == "FormattedLogValues"),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+        }
+
+        [Fact]
+        public async Task SearchTenuresSets_ReturnsEmptyResultsWhenRequestIsNull()
+        {
+            var result = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(null);
+
+            result.Documents.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task SearchTenuresSets_CallsSearchAsyncOnESClient()
+        {
+            var mockResponse = new Mock<SearchResponse<QueryableTenure>>();
+
+            _elasticClientMock.Setup(x =>
+                x.SearchAsync<QueryableTenure>(
+                It.IsAny<Func<SearchDescriptor<QueryableTenure>, ISearchRequest<QueryableTenure>>>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(mockResponse.Object);
+
+            var result = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(_request);
+
+            _elasticClientMock.Verify(x =>
+                x.SearchAsync<QueryableTenure>(
+                It.IsAny<Func<SearchDescriptor<QueryableTenure>, ISearchRequest<QueryableTenure>>>(),
+                default(CancellationToken)), Times.Once);
+        }
+    }
+}
+
+

--- a/HousingSearchApi.Tests/V1/UseCases/GetTenureListSetsUseCaseTests.cs
+++ b/HousingSearchApi.Tests/V1/UseCases/GetTenureListSetsUseCaseTests.cs
@@ -1,0 +1,53 @@
+using AutoFixture;
+using FluentAssertions;
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Responses;
+using HousingSearchApi.V1.Gateways.Interfaces;
+using HousingSearchApi.V1.UseCase;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V1.UseCases
+{
+    public class GetTenureListSetsUseCaseTests
+    {
+        private readonly GetTenureListSetsUseCase _classUnderTest;
+        private readonly Mock<ISearchGateway> _mockSearchGateway;
+        private readonly GetAllTenureListRequest _request;
+        private readonly Fixture _fixture;
+
+        public GetTenureListSetsUseCaseTests()
+        {
+            _mockSearchGateway = new Mock<ISearchGateway>();
+            _classUnderTest = new GetTenureListSetsUseCase(_mockSearchGateway.Object);
+            _fixture = new Fixture();
+
+            _request = _fixture.Create<GetAllTenureListRequest>();
+        }
+
+        [Fact]
+        public async Task CallsGetListOfTenuresSetsWithGetAllTenureListRequest()
+        {
+            _mockSearchGateway
+                .Setup(x => x.GetListOfTenuresSets(_request))
+                .ReturnsAsync(new GetAllTenureListResponse());
+
+            _ = await _classUnderTest.ExecuteAsync(_request);
+
+            _mockSearchGateway.Verify(x => x.GetListOfTenuresSets(_request), Times.Once);
+        }
+
+        [Fact]
+        public async Task ReturnsGetAllTenureListResponseObject()
+        {
+            _mockSearchGateway
+                .Setup(x => x.GetListOfTenuresSets(It.IsAny<GetAllTenureListRequest>()))
+                .ReturnsAsync(new GetAllTenureListResponse());
+
+            var response = await _classUnderTest.ExecuteAsync(_request);
+
+            response.Should().BeOfType<GetAllTenureListResponse>();
+        }
+    }
+}

--- a/HousingSearchApi/Startup.cs
+++ b/HousingSearchApi/Startup.cs
@@ -1,14 +1,28 @@
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using FluentValidation.AspNetCore;
+using Hackney.Core.ElasticSearch;
+using Hackney.Core.ElasticSearch.Interfaces;
 using Hackney.Core.HealthCheck;
 using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Core.Middleware.CorrelationId;
 using Hackney.Core.Middleware.Exception;
 using Hackney.Core.Middleware.Logging;
+using Hackney.Shared.HousingSearch.Domain.Asset;
+using HousingSearchApi.V1.Gateways;
+using HousingSearchApi.V1.Gateways.Interfaces;
 using HousingSearchApi.V1.HealthCheck;
+using HousingSearchApi.V1.Helper;
+using HousingSearchApi.V1.Helper.Interfaces;
 using HousingSearchApi.V1.Infrastructure;
+using HousingSearchApi.V1.Infrastructure.Core;
+using HousingSearchApi.V1.Infrastructure.Extensions;
+using HousingSearchApi.V1.Infrastructure.Factories;
+using HousingSearchApi.V1.Infrastructure.Filtering;
+using HousingSearchApi.V1.Infrastructure.Sorting;
 using HousingSearchApi.V1.Interfaces;
+using HousingSearchApi.V1.Interfaces.Factories;
+using HousingSearchApi.V1.Interfaces.Filtering;
 using HousingSearchApi.V1.Interfaces.Sorting;
 using HousingSearchApi.V1.UseCase;
 using HousingSearchApi.V1.UseCase.Interfaces;
@@ -32,20 +46,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Hackney.Core.ElasticSearch;
-using Hackney.Core.ElasticSearch.Interfaces;
-using HousingSearchApi.V1.Gateways.Interfaces;
-using HousingSearchApi.V1.Gateways;
-using HousingSearchApi.V1.Infrastructure.Extensions;
-using HousingSearchApi.V1.Infrastructure.Factories;
-using HousingSearchApi.V1.Infrastructure.Filtering;
-using HousingSearchApi.V1.Infrastructure.Sorting;
-using HousingSearchApi.V1.Interfaces.Factories;
-using HousingSearchApi.V1.Interfaces.Filtering;
-using HousingSearchApi.V1.Infrastructure.Core;
-using Hackney.Shared.HousingSearch.Domain.Asset;
-using HousingSearchApi.V1.Helper;
-using HousingSearchApi.V1.Helper.Interfaces;
 
 namespace HousingSearchApi
 {
@@ -180,6 +180,7 @@ namespace HousingSearchApi
             services.AddScoped<IGetPersonListUseCase, GetPersonListUseCase>();
             services.AddScoped<IGetAccountListUseCase, GetAccountListUseCase>();
             services.AddScoped<IGetTenureListUseCase, GetTenureListUseCase>();
+            services.AddScoped<IGetTenureListSetsUseCase, GetTenureListSetsUseCase>();
             services.AddScoped<IElasticSearchWrapper, ElasticSearchWrapper>();
             services.AddScoped<IPagingHelper, PagingHelper>();
             services.AddScoped<ISortFactory, SortFactory>();

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllTenureListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllTenureListRequest.cs
@@ -6,5 +6,9 @@ namespace HousingSearchApi.V1.Boundary.Requests
     {
         [FromQuery(Name = "lastHitId")]
         public string LastHitId { get; set; }
+
+        //in order to use sorting together with last hit id, this must be provided as well 
+        [FromQuery(Name = "lastHitTenureStartDate")]
+        public string LastHitTenureStartDate { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllTenureListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllTenureListRequest.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace HousingSearchApi.V1.Boundary.Requests
+{
+    public class GetAllTenureListRequest : GetTenureListRequest
+    {
+        [FromQuery(Name = "lastHitId")]
+        public string LastHitId { get; set; }
+    }
+}

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Hackney.Core.Validation;
+using System;
 
 namespace HousingSearchApi.V1.Boundary.Requests.Validation
 {
@@ -12,18 +13,34 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
                 RuleFor(x => x.LastHitTenureStartDate).NotXssString();
 
                 RuleFor(x => x.LastHitTenureStartDate)
-                .Custom((tenureStartDate, context) =>
-                {
-                    var dateIsInCorrectFormat = long.TryParse(tenureStartDate, out var dateInMilliseconds);
-
-                    if (!dateIsInCorrectFormat)
+                    .Custom((tenureStartDate, context) =>
                     {
-                        context.AddFailure("LastHitTenureStartDate must be provided in milliseconds since epoch format");
-                    }
-                });
+                        var dateIsInCorrectFormat = long.TryParse(tenureStartDate, out var dateInMilliseconds);
+
+                        if (!dateIsInCorrectFormat)
+                        {
+                            context.AddFailure("LastHitTenureStartDate must be provided in milliseconds since epoch format");
+                        }
+                    });
 
                 RuleFor(x => x.LastHitId).NotEmpty().WithMessage("LastHitId must be provided with LastHitTenureStartDate");
             });
+
+            RuleFor(x => x.LastHitId).NotXssString();
+
+            When(x => !string.IsNullOrEmpty(x.LastHitId), () =>
+                RuleFor(x => x.LastHitId)
+                    .Custom((lastHitId, context) =>
+                    {
+                        var lastHitIdGuid = Guid.TryParse(lastHitId, out var guid);
+
+                        if (!lastHitIdGuid)
+                        {
+                            context.AddFailure("LastHitId is not in a valid Guid format");
+                        };
+
+                    })
+             );
         }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using Hackney.Core.Validation;
+
+namespace HousingSearchApi.V1.Boundary.Requests.Validation
+{
+    public class GetAllTenureListRequestValidator : AbstractValidator<GetAllTenureListRequest>
+    {
+        public GetAllTenureListRequestValidator()
+        {
+            When(x => !string.IsNullOrEmpty(x.LastHitTenureStartDate), () =>
+            {
+                RuleFor(x => x.LastHitTenureStartDate).NotXssString();
+
+                RuleFor(x => x.LastHitTenureStartDate)
+                .Custom((tenureStartDate, context) =>
+                {
+                    var dateIsInCorrectFormat = long.TryParse(tenureStartDate, out var dateInMilliseconds);
+
+                    if (!dateIsInCorrectFormat)
+                    {
+                        context.AddFailure("LastHitTenureStartDate must be provided in milliseconds since epoch format");
+                    }
+                });
+            });
+        }
+    }
+}
+
+

--- a/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/Validation/GetAllTenureListRequestValidator.cs
@@ -21,6 +21,8 @@ namespace HousingSearchApi.V1.Boundary.Requests.Validation
                         context.AddFailure("LastHitTenureStartDate must be provided in milliseconds since epoch format");
                     }
                 });
+
+                RuleFor(x => x.LastHitId).NotEmpty().WithMessage("LastHitId must be provided with LastHitTenureStartDate");
             });
         }
     }

--- a/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
+++ b/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
@@ -1,20 +1,13 @@
+using Newtonsoft.Json;
+
 namespace HousingSearchApi.V1.Boundary.Responses
 {
     public class GetAllTenureListResponse : GetTenureListResponse
     {
-        private string _lastHitTenureStartDate;
-        private string _lastHitId;
+        [JsonIgnore]
+        public string LastHitTenureStartDate { get; set; }
 
-        internal string LastHitTenureStartDate
-        {
-            get => _lastHitTenureStartDate;
-            set => _lastHitTenureStartDate = value;
-        }
-
-        internal string LastHitId
-        {
-            get => _lastHitId;
-            set => _lastHitId = value;
-        }
+        [JsonIgnore]
+        public string LastHitId { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
+++ b/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
@@ -2,6 +2,27 @@ namespace HousingSearchApi.V1.Boundary.Responses
 {
     public class GetAllTenureListResponse : GetTenureListResponse
     {
-        public string LastHitId { get; set; }
+        private string _lastHitId;
+        private string _lastHitTenureStartDate;
+
+        public void SetLastHitId(string lastHitId)
+        {
+            _lastHitId = lastHitId;
+        }
+
+        public string LastHitId()
+        {
+            return _lastHitId;
+        }
+
+        public void SetLastHitTenureStartDate(string tenureStartDate)
+        {
+            _lastHitTenureStartDate = tenureStartDate;
+        }
+
+        public string LastHitTenureStartDate()
+        {
+            return _lastHitTenureStartDate;
+        }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
+++ b/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
@@ -2,27 +2,19 @@ namespace HousingSearchApi.V1.Boundary.Responses
 {
     public class GetAllTenureListResponse : GetTenureListResponse
     {
-        private string _lastHitId;
         private string _lastHitTenureStartDate;
+        private string _lastHitId;
 
-        public void SetLastHitId(string lastHitId)
+        internal string LastHitTenureStartDate
         {
-            _lastHitId = lastHitId;
+            get => _lastHitTenureStartDate;
+            set => _lastHitTenureStartDate = value;
         }
 
-        public string LastHitId()
+        internal string LastHitId
         {
-            return _lastHitId;
-        }
-
-        public void SetLastHitTenureStartDate(string tenureStartDate)
-        {
-            _lastHitTenureStartDate = tenureStartDate;
-        }
-
-        public string LastHitTenureStartDate()
-        {
-            return _lastHitTenureStartDate;
+            get => _lastHitId;
+            set => _lastHitId = value;
         }
     }
 }

--- a/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
+++ b/HousingSearchApi/V1/Boundary/Responses/GetAllTenureListResponse.cs
@@ -1,0 +1,7 @@
+namespace HousingSearchApi.V1.Boundary.Responses
+{
+    public class GetAllTenureListResponse : GetTenureListResponse
+    {
+        public string LastHitId { get; set; }
+    }
+}

--- a/HousingSearchApi/V1/Boundary/Responses/Metadata/APIAllTenureResponse.cs
+++ b/HousingSearchApi/V1/Boundary/Responses/Metadata/APIAllTenureResponse.cs
@@ -1,0 +1,7 @@
+namespace HousingSearchApi.V1.Boundary.Responses.Metadata
+{
+    public class APIAllTenureResponse<T> : APIAllResponse<T> where T : class
+    {
+        public string LastHitTenureStartDate { get; set; }
+    }
+}

--- a/HousingSearchApi/V1/Controllers/GetTenureListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetTenureListController.cs
@@ -47,6 +47,9 @@ namespace HousingSearchApi.V1.Controllers
             }
         }
 
+        /// <summary>
+        /// Last hit id paging is only supported when sorting by tenureStartDate. Any other type of paging is not supported. Page size can be set however when using tenureStartDate sorting with last hit id paging
+        /// </summary>
         [ProducesResponseType(typeof(APIAllTenureResponse<GetAllTenureListResponse>), 200)]
         [ProducesResponseType(typeof(APIAllTenureResponse<BadRequestObjectResult>), 400)]
         [Route("all")]

--- a/HousingSearchApi/V1/Controllers/GetTenureListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetTenureListController.cs
@@ -47,8 +47,8 @@ namespace HousingSearchApi.V1.Controllers
             }
         }
 
-        [ProducesResponseType(typeof(APIAllResponse<GetAllTenureListResponse>), 200)]
-        [ProducesResponseType(typeof(APIAllResponse<BadRequestObjectResult>), 400)]
+        [ProducesResponseType(typeof(APIAllTenureResponse<GetAllTenureListResponse>), 200)]
+        [ProducesResponseType(typeof(APIAllTenureResponse<BadRequestObjectResult>), 400)]
         [Route("all")]
         [HttpGet, MapToApiVersion("1")]
         [LogCall(Microsoft.Extensions.Logging.LogLevel.Information)]
@@ -59,10 +59,13 @@ namespace HousingSearchApi.V1.Controllers
             {
                 var searchResults = await _getTenureListSetsUseCase.ExecuteAsync(request).ConfigureAwait(false);
 
-                var response = new APIAllResponse<GetAllTenureListResponse>(searchResults)
+                var response = new APIAllTenureResponse<GetAllTenureListResponse>()
                 {
                     Total = searchResults.Total(),
-                    LastHitId = searchResults.LastHitId
+                    LastHitId = searchResults.LastHitId(),
+                    LastHitTenureStartDate = searchResults.LastHitTenureStartDate(),
+                    Results = searchResults
+
                 };
 
                 return new OkObjectResult(response);

--- a/HousingSearchApi/V1/Controllers/GetTenureListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetTenureListController.cs
@@ -62,8 +62,8 @@ namespace HousingSearchApi.V1.Controllers
                 var response = new APIAllTenureResponse<GetAllTenureListResponse>()
                 {
                     Total = searchResults.Total(),
-                    LastHitId = searchResults.LastHitId(),
-                    LastHitTenureStartDate = searchResults.LastHitTenureStartDate(),
+                    LastHitId = searchResults.LastHitId,
+                    LastHitTenureStartDate = searchResults.LastHitTenureStartDate,
                     Results = searchResults
 
                 };

--- a/HousingSearchApi/V1/Controllers/GetTenureListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetTenureListController.cs
@@ -5,7 +5,6 @@ using HousingSearchApi.V1.Boundary.Responses;
 using HousingSearchApi.V1.Boundary.Responses.Metadata;
 using HousingSearchApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -18,10 +17,12 @@ namespace HousingSearchApi.V1.Controllers
     public class GetTenureListController : BaseController
     {
         private readonly IGetTenureListUseCase _getTenureListUseCase;
+        private readonly IGetTenureListSetsUseCase _getTenureListSetsUseCase;
 
-        public GetTenureListController(IGetTenureListUseCase getTenureListUseCase)
+        public GetTenureListController(IGetTenureListUseCase getTenureListUseCase, IGetTenureListSetsUseCase getTenureListSetsUseCase)
         {
             _getTenureListUseCase = getTenureListUseCase;
+            _getTenureListSetsUseCase = getTenureListSetsUseCase;
         }
 
         [ProducesResponseType(typeof(APIResponse<GetTenureListResponse>), 200)]
@@ -38,6 +39,33 @@ namespace HousingSearchApi.V1.Controllers
                 apiResponse.Total = tenuresSearchResult.Total();
 
                 return new OkObjectResult(apiResponse);
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log(e.Message + e.StackTrace);
+                return new BadRequestObjectResult(e.Message);
+            }
+        }
+
+        [ProducesResponseType(typeof(APIAllResponse<GetAllTenureListResponse>), 200)]
+        [ProducesResponseType(typeof(APIAllResponse<BadRequestObjectResult>), 400)]
+        [Route("all")]
+        [HttpGet, MapToApiVersion("1")]
+        [LogCall(Microsoft.Extensions.Logging.LogLevel.Information)]
+
+        public async Task<IActionResult> GetAllTenureList([FromQuery] GetAllTenureListRequest request)
+        {
+            try
+            {
+                var searchResults = await _getTenureListSetsUseCase.ExecuteAsync(request).ConfigureAwait(false);
+
+                var response = new APIAllResponse<GetAllTenureListResponse>(searchResults)
+                {
+                    Total = searchResults.Total(),
+                    LastHitId = searchResults.LastHitId
+                };
+
+                return new OkObjectResult(response);
             }
             catch (Exception e)
             {

--- a/HousingSearchApi/V1/Controllers/GetTenureListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetTenureListController.cs
@@ -65,7 +65,6 @@ namespace HousingSearchApi.V1.Controllers
                     LastHitId = searchResults.LastHitId,
                     LastHitTenureStartDate = searchResults.LastHitTenureStartDate,
                     Results = searchResults
-
                 };
 
                 return new OkObjectResult(response);

--- a/HousingSearchApi/V1/Gateways/Interfaces/ISearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/Interfaces/ISearchGateway.cs
@@ -1,9 +1,9 @@
+using Hackney.Shared.HousingSearch.Domain.Asset;
 using HousingSearchApi.V1.Boundary.Requests;
 using HousingSearchApi.V1.Boundary.Responses;
-using System.Threading.Tasks;
 using HousingSearchApi.V1.Boundary.Responses.Transactions;
-using Hackney.Shared.HousingSearch.Domain.Asset;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace HousingSearchApi.V1.Gateways.Interfaces
 {
@@ -11,6 +11,7 @@ namespace HousingSearchApi.V1.Gateways.Interfaces
     {
         Task<GetPersonListResponse> GetListOfPersons(GetPersonListRequest query);
         Task<GetTenureListResponse> GetListOfTenures(GetTenureListRequest query);
+        Task<GetAllTenureListResponse> GetListOfTenuresSets(GetAllTenureListRequest query);
         Task<GetAssetListResponse> GetListOfAssets(GetAssetListRequest query);
         Task<GetAllAssetListResponse> GetListOfAssetsSets(GetAllAssetListRequest query);
         Task<GetAccountListResponse> GetListOfAccounts(GetAccountListRequest query);

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -235,8 +235,8 @@ namespace HousingSearchApi.V1.Gateways
                     var lastHit = searchResponse.Hits.Last();
                     var lastHitTenureStartDate = lastHit.Sorts?.Count > 0 ? lastHit.Sorts.First() : null;
 
-                    tenureListResponse.SetLastHitId(lastHit.Id);
-                    tenureListResponse.SetLastHitTenureStartDate(lastHitTenureStartDate?.ToString()); //[tenure start date, id]
+                    tenureListResponse.LastHitId = lastHit.Id;
+                    tenureListResponse.LastHitTenureStartDate = lastHitTenureStartDate?.ToString(); //[tenure start date, id]
                 }
 
                 return tenureListResponse;

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -213,7 +213,7 @@ namespace HousingSearchApi.V1.Gateways
         public async Task<GetAllTenureListResponse> GetListOfTenuresSets(GetAllTenureListRequest query)
         {
             var searchResponse = await _elasticSearchWrapper
-                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query)
+                .SearchTenuresSets(query)
                 .ConfigureAwait(false);
 
             var tenureListResponse = new GetAllTenureListResponse();
@@ -232,7 +232,11 @@ namespace HousingSearchApi.V1.Gateways
 
                 if (searchResponse.Documents.Count > 0)
                 {
-                    tenureListResponse.LastHitId = searchResponse.Hits.Last().Id;
+                    var lastHit = searchResponse.Hits.Last();
+                    var lastHitTenureStartDate = lastHit.Sorts?.Count > 0 ? lastHit.Sorts.First() : null;
+
+                    tenureListResponse.SetLastHitId(lastHit.Id);
+                    tenureListResponse.SetLastHitTenureStartDate(lastHitTenureStartDate?.ToString()); //[tenure start date, id]
                 }
 
                 return tenureListResponse;

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -209,5 +209,19 @@ namespace HousingSearchApi.V1.Gateways
 
             return childAssets;
         }
+
+        public async Task<GetAllTenureListResponse> GetListOfTenuresSets(GetAllTenureListRequest query)
+        {
+            var searchResponse = await _elasticSearchWrapper
+                .SearchTenuresSets<QueryableTenure, GetAllTenureListRequest>(query)
+                .ConfigureAwait(false);
+
+            var tenureListResponse = new GetAllTenureListResponse();
+
+            //TODO: mock Documents
+            //tenureListResponse.Tenures.AddRange(searchResponse.Documents.Select(qt => qt.Create()));
+
+            return tenureListResponse;
+        }
     }
 }

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -230,7 +230,7 @@ namespace HousingSearchApi.V1.Gateways
 
                 tenureListResponse.SetTotal(searchResponse.Total);
 
-                if (searchResponse.Documents.Count > 0)
+                if (searchResponse.Documents.Any())
                 {
                     var lastHit = searchResponse.Hits.Last();
                     var lastHitTenureStartDate = lastHit.Sorts?.FirstOrDefault(defaultValue: null);

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -233,8 +233,7 @@ namespace HousingSearchApi.V1.Gateways
                 if (searchResponse.Documents.Count > 0)
                 {
                     var lastHit = searchResponse.Hits.Last();
-                    var lastHitTenureStartDate = lastHit.Sorts?.Count > 0 ? lastHit.Sorts.First() : null;
-
+                    var lastHitTenureStartDate = lastHit.Sorts?.FirstOrDefault(defaultValue: null);
                     tenureListResponse.LastHitId = lastHit.Id;
                     tenureListResponse.LastHitTenureStartDate = lastHitTenureStartDate?.ToString(); //[tenure start date, id]
                 }

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -218,10 +218,26 @@ namespace HousingSearchApi.V1.Gateways
 
             var tenureListResponse = new GetAllTenureListResponse();
 
-            //TODO: mock Documents
-            //tenureListResponse.Tenures.AddRange(searchResponse.Documents.Select(qt => qt.Create()));
+            if (searchResponse == null)
+            {
+                return tenureListResponse;
+            }
+            else
+            {
+                tenureListResponse
+                    .Tenures
+                    .AddRange(searchResponse.Documents.Select(queryableTenure => queryableTenure.Create()));
 
-            return tenureListResponse;
+                tenureListResponse.SetTotal(searchResponse.Total);
+
+                if (searchResponse.Documents.Count > 0)
+                {
+                    tenureListResponse.LastHitId = searchResponse.Hits.Last().Id;
+                }
+
+                return tenureListResponse;
+            }
         }
     }
 }
+

--- a/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
@@ -133,8 +133,8 @@ namespace HousingSearchApi.V1.Infrastructure
                 return new SearchResponse<QueryableTenure>();
             }
 
-            //last hit paging is only supported when sorting by tenure start date
-            //any other type of paging is not supported. Page size can be set however when using start date sorting with last hit paging
+            //Last hit id paging is only supported when sorting by tenureStartDate. Any other type of paging is not supported.
+            //Page size can be set however when using tenureStartDate sorting with last hit id paging
             var sortDescriptor = _sortFactory.Create<QueryableTenure, GetAllTenureListRequest>(request).GetSortDescriptor;
 
             var lastSortedItem = GetLastSortedItem(request);

--- a/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
@@ -121,21 +121,28 @@ namespace HousingSearchApi.V1.Infrastructure
             }
 
         }
-
         public async Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest request)
             where T : class
             where TRequest : GetAllTenureListRequest
         {
             var esNodes = string.Join(';', _esClient.ConnectionSettings.ConnectionPool.Nodes.Select(x => x.Uri));
 
-            _logger.LogDebug($"ElasticSearch Search Sets begins {esNodes}");
+            _logger.LogDebug($"ElasticSearch Search Tenures Sets begins {esNodes}");
 
             if (request == null)
             {
                 return new SearchResponse<T>();
             }
 
-            return await _esClient.SearchAsync<T>().ConfigureAwait(false);
+            try
+            {
+                return await _esClient.SearchAsync<T>().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "ElasticSearch Search Tenures Sets threw an exception");
+                throw;
+            }
         }
 
         private IQueryGenerator<T> BaseQuery<T>() where T : class

--- a/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
@@ -122,11 +122,20 @@ namespace HousingSearchApi.V1.Infrastructure
 
         }
 
-        public Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest query)
+        public async Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest request)
             where T : class
             where TRequest : GetAllTenureListRequest
         {
-            throw new NotImplementedException();
+            var esNodes = string.Join(';', _esClient.ConnectionSettings.ConnectionPool.Nodes.Select(x => x.Uri));
+
+            _logger.LogDebug($"ElasticSearch Search Sets begins {esNodes}");
+
+            if (request == null)
+            {
+                return new SearchResponse<T>();
+            }
+
+            return await _esClient.SearchAsync<T>().ConfigureAwait(false);
         }
 
         private IQueryGenerator<T> BaseQuery<T>() where T : class

--- a/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Infrastructure/ElasticElasticSearchWrapper.cs
@@ -1,14 +1,14 @@
+using Elasticsearch.Net;
 using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Interfaces;
+using HousingSearchApi.V1.Interfaces.Factories;
+using HousingSearchApi.V1.Interfaces.Filtering;
 using HousingSearchApi.V1.Interfaces.Sorting;
 using Microsoft.Extensions.Logging;
 using Nest;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Elasticsearch.Net;
-using HousingSearchApi.V1.Interfaces;
-using HousingSearchApi.V1.Interfaces.Factories;
-using HousingSearchApi.V1.Interfaces.Filtering;
 
 namespace HousingSearchApi.V1.Infrastructure
 {
@@ -120,6 +120,13 @@ namespace HousingSearchApi.V1.Infrastructure
                 throw;
             }
 
+        }
+
+        public Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest query)
+            where T : class
+            where TRequest : GetAllTenureListRequest
+        {
+            throw new NotImplementedException();
         }
 
         private IQueryGenerator<T> BaseQuery<T>() where T : class

--- a/HousingSearchApi/V1/Infrastructure/Sorting/TenureStartDateAsc.cs
+++ b/HousingSearchApi/V1/Infrastructure/Sorting/TenureStartDateAsc.cs
@@ -8,7 +8,12 @@ namespace HousingSearchApi.V1.Infrastructure.Sorting
     {
         public SortDescriptor<QueryableTenure> GetSortDescriptor(SortDescriptor<QueryableTenure> descriptor)
         {
-            return descriptor.Ascending(f => f.StartOfTenureDate);
+            // in the current schema the id field is defined as multi-field, so we need to use the id.keyword property to allow sorting
+            // if the id field was defined as keyword then this wouldn't be necessary
+
+            // both start date and id must be provided for this sorting to work
+
+            return descriptor.Ascending(x => x.StartOfTenureDate).Field("id.keyword", SortOrder.Ascending);
         }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Sorting/TenureStartDateDesc.cs
+++ b/HousingSearchApi/V1/Infrastructure/Sorting/TenureStartDateDesc.cs
@@ -8,7 +8,11 @@ namespace HousingSearchApi.V1.Infrastructure.Sorting
     {
         public SortDescriptor<QueryableTenure> GetSortDescriptor(SortDescriptor<QueryableTenure> descriptor)
         {
-            return descriptor.Descending(f => f.StartOfTenureDate);
+            // in the current schema the id field is defined as multi-field, so we need to use the id.keyword property to allow sorting
+            // if the id field was defined as keyword then this wouldn't be necessary
+
+            // both start date and id must be provided for this sorting to work
+            return descriptor.Descending(x => x.StartOfTenureDate).Field("id.keyword", SortOrder.Descending);
         }
     }
 }

--- a/HousingSearchApi/V1/Interfaces/IElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Interfaces/IElasticSearchWrapper.cs
@@ -1,5 +1,6 @@
-using System.Threading.Tasks;
+using HousingSearchApi.V1.Boundary.Requests;
 using Nest;
+using System.Threading.Tasks;
 
 namespace HousingSearchApi.V1.Interfaces
 {
@@ -8,5 +9,7 @@ namespace HousingSearchApi.V1.Interfaces
         Task<ISearchResponse<T>> Search<T, TRequest>(TRequest request) where T : class where TRequest : class;
 
         Task<ISearchResponse<T>> SearchSets<T, TRequest>(TRequest request) where T : class where TRequest : class;
+
+        Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest query) where T : class where TRequest : GetAllTenureListRequest;
     }
 }

--- a/HousingSearchApi/V1/Interfaces/IElasticSearchWrapper.cs
+++ b/HousingSearchApi/V1/Interfaces/IElasticSearchWrapper.cs
@@ -1,3 +1,4 @@
+using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 using HousingSearchApi.V1.Boundary.Requests;
 using Nest;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ namespace HousingSearchApi.V1.Interfaces
 
         Task<ISearchResponse<T>> SearchSets<T, TRequest>(TRequest request) where T : class where TRequest : class;
 
-        Task<ISearchResponse<T>> SearchTenuresSets<T, TRequest>(TRequest query) where T : class where TRequest : GetAllTenureListRequest;
+        Task<ISearchResponse<QueryableTenure>> SearchTenuresSets(GetAllTenureListRequest query);
+
     }
 }

--- a/HousingSearchApi/V1/UseCase/GetTenureListSetsUseCase.cs
+++ b/HousingSearchApi/V1/UseCase/GetTenureListSetsUseCase.cs
@@ -1,0 +1,22 @@
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Responses;
+using HousingSearchApi.V1.Gateways.Interfaces;
+using HousingSearchApi.V1.UseCase.Interfaces;
+using System.Threading.Tasks;
+
+namespace HousingSearchApi.V1.UseCase
+{
+    public class GetTenureListSetsUseCase : IGetTenureListSetsUseCase
+    {
+        private readonly ISearchGateway _searchGateway;
+
+        public GetTenureListSetsUseCase(ISearchGateway searchGateway)
+        {
+            _searchGateway = searchGateway;
+        }
+        public async Task<GetAllTenureListResponse> ExecuteAsync(GetAllTenureListRequest request)
+        {
+            return await _searchGateway.GetListOfTenuresSets(request).ConfigureAwait(false);
+        }
+    }
+}

--- a/HousingSearchApi/V1/UseCase/Interfaces/IGetTenureListSetsUseCase.cs
+++ b/HousingSearchApi/V1/UseCase/Interfaces/IGetTenureListSetsUseCase.cs
@@ -1,0 +1,11 @@
+using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Boundary.Responses;
+using System.Threading.Tasks;
+
+namespace HousingSearchApi.V1.UseCase.Interfaces
+{
+    public interface IGetTenureListSetsUseCase
+    {
+        Task<GetAllTenureListResponse> ExecuteAsync(GetAllTenureListRequest request);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1441](https://hackney.atlassian.net/browse/TS-1441)

## Describe this PR

### *What is the problem we're trying to solve*

Bookings worktray used in Temporary Accommodation needs a last hit id based paged list of tenures sorted by tenure start date. Current tenure search end point does not support that functionality.

### *What changes have we introduced*

This update adds new `/tenures/all` end point that supports last hit id based paging while tenure start date based sorting is used at the same time. It supports the same search functionality as the current tenure search endpoint by using the same tenure query builder. Everything else has been kept separate for easier development further down the file. If the search functionality needs to be changed later new query builer can be implemented, so that these end points can be developed separately.

This update only covers the TA worktray sorting and paging (load more) use case and any other kind of paging and sorting by different values are not supported. They can be developed later as and when required.  

Basic usage for the new paging feature is:
`/all?searchText=%22%22&sortBy=tenureStartDate&isDesc=true&pageSize=7`

Updates include:

1. Add new `/all` end point to the `GetTenureListController`. The current implementation of `LambdaLogger` in the API does not really support testing, so that hasn't been covered. That's something we can look at improving API wide
2. Add e2e tests to cover the functionality of the new end point
3. Add test coverage for the `ElasticSearchWrapper` which currently does not have any tests. Approach taken with Elastic Search client is that the e2e tests are used to determine whether the client returns correct results rather than trying to mock the client and then verify that it's been called correctly. Those various extension methods would make mocking the client cumbersome and it's generally adviced against to try to mock it that way anyway
4. Addthe new `GetTenureListSetsUseCase` service to the Startup. Other changes in that file are purely formatting and sorting usings
5. Update `GetAllTenureListRequest` to include `LastHitTenureStartDate` property. When sorting is used in ES together with last hit id approach, both the id and the sorting value must be passed to the ES client. In this particular use case the LastHitTenureStartDate must be passed as well as the id of the last hit. Important thing to note about the date is that it must be provided in milliseconds since Unix Epoch. ES client returns the value in that format for the next set, so it's easy to pass it to the client in the same format
6. Add new `GetAllTenureListResponse` object that inherits from `GetTenureListResponse`
7. Add new `APIAllTenureResponse<T>` that inherits from `APIAllResponse<T>`. This way we don't have to pollute the `APIAllResponse` response with the `LastHitTenureStartDate` when it's not required. Such as in assets all response 
8. Add new `GetListOfTenuresSets` search gateway method.
9. Sort descriptor for `QueryableTenure` has been updated to include both tenure start date and last hit id. These both are required for ES to be able to work out what the last result set was and what should be returned next
10. Add `GetAllTenureListRequestValidator` boundary object validator to cover the new `LastHitTenureStartDate` property 

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update the TA worktray to use the new end point.


[TS-1441]: https://hackney.atlassian.net/browse/TS-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ