### PR TITLE
Update shared package to 0.73.0

### DIFF
--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.72.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.73.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />


### PR DESCRIPTION
### What
This PR updates the housing search shared package to the latest 0.73.0.
### Why
To introduce the new nullable fields from this [PR](https://github.com/LBHackney-IT/housing-search-shared/pull/77)