### PR TITLE
TS-1528: 

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -18,22 +18,22 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids()},
+                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true},
             new AddressStub{ FirstLine = "54 Buckland Court St Johns Estate", AssetType = "Estate", PostCode = "N1 5EP", UPRN = "10008234655",
-                AssetStatus = "Archived", NoOfBedSpaces = 3, NoOfCots = 0, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = false, ParentAssetIds = GetGuids(), ContractIsApproved = false},
+                AssetStatus = "Archived", NoOfBedSpaces = 3, NoOfCots = 0, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = false, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true},
             new AddressStub{ FirstLine = "65 Buckland Court St Johns Estate", AssetType = "TerracedBlock", PostCode = "N1 5EP", UPRN = "10008234605",
-                AssetStatus = "In council use", NoOfBedSpaces = 4, NoOfCots = 2, HasStairs = true, PrivateBathroom = false, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsApproved = false},
+                AssetStatus = "In council use", NoOfBedSpaces = 4, NoOfCots = 2, HasStairs = true, PrivateBathroom = false, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = false},
             new AddressStub{ FirstLine = "45 Buckland Court St Johns Estate", AssetType = "HighRiseBlock", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Occupied", NoOfBedSpaces = 5, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids()},
+                AssetStatus = "Occupied", NoOfBedSpaces = 5, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true},
             new AddressStub{ FirstLine = "Gge 45 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Vacant", NoOfBedSpaces = 1, NoOfCots = 0, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, ParentAssetIds = "85301d37-c9b4-4c5e-b218-effd4f0b2d7c#56043135-96e3-40cc-bb5a-598c25c47b44", ContractIsApproved = false},
+                AssetStatus = "Vacant", NoOfBedSpaces = 1, NoOfCots = 0, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, ParentAssetIds = "85301d37-c9b4-4c5e-b218-effd4f0b2d7c#56043135-96e3-40cc-bb5a-598c25c47b44", ContractIsApproved = false, ContractIsActive = true},
             new AddressStub{ FirstLine = "Gge 52 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Void", NoOfBedSpaces = 2, NoOfCots = 0, HasStairs = false, PrivateBathroom = false, PrivateKitchen = true, StepFree = true, ParentAssetIds = "01da3724-1eff-4a91-9bed-923582ae142d#85301d37-c9b4-4c5e-b218-effd4f0b2d7c#52f7309c-305f-4cf6-b0e7-d021cd5c71c0", ContractIsApproved = false},
-            new AddressStub{ FirstLine = "Gge 51 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = false},
-            new AddressStub{ FirstLine = "5 Buckland Court St Johns Estate", AssetType = "FirstAsset", PostCode = "N1 6TY", UPRN = "10008235183", ContractIsApproved = false},
-            new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true},
-            new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsApproved = false},
-            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true}
+                AssetStatus = "Void", NoOfBedSpaces = 2, NoOfCots = 0, HasStairs = false, PrivateBathroom = false, PrivateKitchen = true, StepFree = true, ParentAssetIds = "01da3724-1eff-4a91-9bed-923582ae142d#85301d37-c9b4-4c5e-b218-effd4f0b2d7c#52f7309c-305f-4cf6-b0e7-d021cd5c71c0", ContractIsApproved = false, ContractIsActive = true},
+            new AddressStub{ FirstLine = "Gge 51 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = false, ContractIsActive = true},
+            new AddressStub{ FirstLine = "5 Buckland Court St Johns Estate", AssetType = "FirstAsset", PostCode = "N1 6TY", UPRN = "10008235183", ContractIsApproved = false, ContractIsActive = true},
+            new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true},
+            new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true},
+            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true}
         };
 
         private static string GetGuids()

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -90,6 +90,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 asset.AssetCharacteristics.IsStepFree = value.StepFree;
                 asset.ParentAssetIds = value.ParentAssetIds;
                 asset.AssetContract.IsApproved = value.ContractIsApproved;
+                asset.AssetContract.IsActive = value.ContractIsActive;
                 listOfAssets.Add(asset);
             }
 
@@ -112,5 +113,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public bool StepFree { get; set; }
         public string ParentAssetIds { get; set; }
         public bool ContractIsApproved { get; set; }
+        public bool ContractIsActive { get; set; }
+
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -86,10 +86,18 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
 
-        public async Task WhenContractIsApprovedIsNotProvided()
+        public async Task WhenNoParameterIsProvided()
         {
             var route = new Uri($"api/v1/search/assets/all?page={1}",
                 UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
+        public async Task WhenContractIsActiveIsProvided(string contractStatus)
+        {
+            var route = new Uri($"api/v1/search/assets/all?contractIsActive={contractStatus}&page={1}",
+                UriKind.Relative);
+
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
         public async Task WhenFloorNoIsProvided(string floorNo)
@@ -204,11 +212,19 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.IsApproved == bool.Parse(contractApprovalStatus));
         }
-        public async Task ThenAllAssetsAreReturned(int amountOfAssets)
+        public async Task ThenAssetsWithProvidedContractStatusShouldBeIncluded(string contractStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
-            result.Results.Assets.Count().Should().Be(amountOfAssets);
+
+            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
+            result.Results.Assets.All(x => x.AssetContract.IsActive == bool.Parse(contractStatus));
+        }
+        public async Task ThenAllAssetsAreReturned(int expectedNumberOfAssets)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -151,10 +151,29 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
         [Fact]
-        public void ServiceReturnsAllAssetsWhenNoContractApprovalStatusIsProvidedWithoutSearchText()
+        public void ServiceFiltersTrueContractIsActiveStatusWithoutSearchText()
+        {
+            var contractIsActive = "true";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractIsActiveIsProvided(contractIsActive))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsActive, 10))
+                .BDDfy();
+        }
+        [Fact]
+        public void ServiceFiltersFalseContractIsActiveStatusWithoutSearchText()
+        {
+            var contractIsNotActive = "false";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractIsActiveIsProvided(contractIsNotActive))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 1))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceReturnsAllAssetsWhenNoParameterIsProvided()
         {
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
-                .When(w => _steps.WhenContractIsApprovedIsNotProvided())
+                .When(w => _steps.WhenNoParameterIsProvided())
                 .Then(t => _steps.ThenAllAssetsAreReturned(11))
                 .BDDfy();
         }

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.74.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.75.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -30,7 +30,8 @@ namespace HousingSearchApi.V1.Boundary.Requests
 
         [FromQuery(Name = "contractIsApproved")]
         public string ContractIsApproved { get; set; }
-
+        [FromQuery(Name = "contractIsActive")]
+        public string ContractIsActive { get; set; }
         [FromQuery(Name = "isTemporaryAccomodation")]
         public string IsTemporaryAccomodation { get; set; }
 

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -80,6 +80,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
                             new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" })
                         .WithExactQuery(assetListAllRequest.SearchText,
@@ -114,6 +115,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })
                         .WithFilterQuery(assetListAllRequest.AssetStatus, new List<string> { "assetManagement.propertyOccupiedStatus" })
                         .WithFilterQuery(assetListAllRequest.TenureType, new List<string> { "tenure.type.keyword" })


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1528

## Describe this PR

### *What is the problem we're trying to solve*

On BTA, contracts that are inactive and not approved are being displayed on the contracts worktray. To avoid this, we need to expose whether the contract is active or not on the AssetContract subentity in the Housing Search.
We have deployed a new package version for this to be saved (https://github.com/LBHackney-IT/housing-search-shared/pull/80), and changes to the listener ([PR here](https://github.com/LBHackney-IT/housing-search-listener/pull/127)).
This PR is for the Housing Search API to be able to use this new parameter as a filter.

### *What changes have we introduced*

Updated package version.
Additions to filter logic.
Tests and small refactoring of one of the preexisting tests as per @adamtry 's comment [here](https://github.com/LBHackney-IT/housing-search-api/pull/231#pullrequestreview-2179994021).