### PR TITLE
TS-1610: Add new ApprovalStatus field to the AssetContract

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using AutoFixture;
 using Elasticsearch.Net;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Persons;
@@ -20,7 +21,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false, ChargesSubType="rate"},
+                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false, ContractApprovalStatus = 0, ChargesSubType="rate"},
             new AddressStub{ FirstLine = "19 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234699",
                 AssetStatus = "Reserved", NoOfBedSpaces = 1, NoOfCots = 1, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false },
             new AddressStub{ FirstLine = "38 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234611",
@@ -123,6 +124,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public bool StepFree { get; set; }
         public string ParentAssetIds { get; set; }
         public bool ContractIsApproved { get; set; }
+        public ApprovalStatus ContractApprovalStatus { get; set;}        
         public bool ContractIsActive { get; set; }
         public string ChargesSubType { get; set; }
         public bool TemporaryAccommodation { get; set; }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -21,26 +21,26 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false, ContractApprovalStatus = 0, ChargesSubType="rate"},
+                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false, ContractApprovalStatus = "PendingApproval", ChargesSubType="rate"},
             new AddressStub{ FirstLine = "19 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234699",
-                AssetStatus = "Reserved", NoOfBedSpaces = 1, NoOfCots = 1, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false },
+                AssetStatus = "Reserved", NoOfBedSpaces = 1, NoOfCots = 1, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractApprovalStatus = "PendingApproval", ContractIsApproved = false },
             new AddressStub{ FirstLine = "38 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234611",
-                AssetStatus = "Occupied", NoOfBedSpaces = 3, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false },
+                AssetStatus = "Occupied", NoOfBedSpaces = 3, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractApprovalStatus = "PendingApproval", ContractIsApproved = false },
             new AddressStub{ FirstLine = "54 Buckland Court St Johns Estate", AssetType = "Estate", PostCode = "N1 5EP", UPRN = "10008234655",
-                AssetStatus = "Archived", NoOfBedSpaces = 3, NoOfCots = 0, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = false, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true},
+                AssetStatus = "Archived", NoOfBedSpaces = 3, NoOfCots = 0, HasStairs = false, PrivateBathroom = true, PrivateKitchen = true, StepFree = false, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true, ContractApprovalStatus = "Approved" },
             new AddressStub{ FirstLine = "65 Buckland Court St Johns Estate", AssetType = "TerracedBlock", PostCode = "N1 5EP", UPRN = "10008234605",
-                AssetStatus = "In council use", NoOfBedSpaces = 4, NoOfCots = 2, HasStairs = true, PrivateBathroom = false, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = false},
+                AssetStatus = "In council use", NoOfBedSpaces = 4, NoOfCots = 2, HasStairs = true, PrivateBathroom = false, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = false, ContractApprovalStatus = "Approved"},
             new AddressStub{ FirstLine = "45 Buckland Court St Johns Estate", AssetType = "HighRiseBlock", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Occupied", NoOfBedSpaces = 5, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false},
+                AssetStatus = "Occupied", NoOfBedSpaces = 5, NoOfCots = 1, HasStairs = false, PrivateBathroom = true, PrivateKitchen = false, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false,  ContractApprovalStatus = "PendingReapproval" },
             new AddressStub{ FirstLine = "Gge 45 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Vacant", NoOfBedSpaces = 1, NoOfCots = 0, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, ParentAssetIds = "85301d37-c9b4-4c5e-b218-effd4f0b2d7c#56043135-96e3-40cc-bb5a-598c25c47b44", ContractIsApproved = false, ContractIsActive = true},
+                AssetStatus = "Vacant", NoOfBedSpaces = 1, NoOfCots = 0, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, ParentAssetIds = "85301d37-c9b4-4c5e-b218-effd4f0b2d7c#56043135-96e3-40cc-bb5a-598c25c47b44", ContractIsApproved = false, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval"},
             new AddressStub{ FirstLine = "Gge 52 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Void", NoOfBedSpaces = 2, NoOfCots = 0, HasStairs = false, PrivateBathroom = false, PrivateKitchen = true, StepFree = true, ParentAssetIds = "01da3724-1eff-4a91-9bed-923582ae142d#85301d37-c9b4-4c5e-b218-effd4f0b2d7c#52f7309c-305f-4cf6-b0e7-d021cd5c71c0", ContractIsApproved = false, ContractIsActive = true},
-            new AddressStub{ FirstLine = "Gge 51 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = false, ContractIsActive = true},
-            new AddressStub{ FirstLine = "5 Buckland Court St Johns Estate", AssetType = "FirstAsset", PostCode = "N1 6TY", UPRN = "10008235183", ContractIsApproved = false, ContractIsActive = true},
-            new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true},
-            new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true},
-            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true}
+                AssetStatus = "Void", NoOfBedSpaces = 2, NoOfCots = 0, HasStairs = false, PrivateBathroom = false, PrivateKitchen = true, StepFree = true, ParentAssetIds = "01da3724-1eff-4a91-9bed-923582ae142d#85301d37-c9b4-4c5e-b218-effd4f0b2d7c#52f7309c-305f-4cf6-b0e7-d021cd5c71c0", ContractIsApproved = false, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval"},
+            new AddressStub{ FirstLine = "Gge 51 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = false, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval"},
+            new AddressStub{ FirstLine = "5 Buckland Court St Johns Estate", AssetType = "FirstAsset", PostCode = "N1 6TY", UPRN = "10008235183", ContractIsApproved = false, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval"},
+            new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval"},
+            new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsApproved = false, ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval"},
+            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval"}
         };
 
         private static string GetGuids()
@@ -85,6 +85,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             {
                 var asset = fixture.Create<QueryableAsset>();
                 var chargeWithSetSubtype = fixture.Create<QueryableCharges>();
+                var parsedApprovalStatus = (ApprovalStatus) Enum.Parse(typeof(ApprovalStatus), value.ContractApprovalStatus);
                 chargeWithSetSubtype.SubType = value.ChargesSubType;
                 asset.AssetAddress.AddressLine1 = value.FirstLine;
                 asset.AssetType = value.AssetType;
@@ -99,6 +100,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 asset.AssetCharacteristics.IsStepFree = value.StepFree;
                 asset.ParentAssetIds = value.ParentAssetIds;
                 asset.AssetContract.IsApproved = value.ContractIsApproved;
+                asset.AssetContract.ApprovalStatus = parsedApprovalStatus;
                 asset.AssetContract.IsActive = value.ContractIsActive;
                 asset.AssetContract.Charges = asset.AssetContract.Charges.Append(chargeWithSetSubtype);
                 asset.AssetManagement.IsTemporaryAccomodation = value.TemporaryAccommodation;
@@ -124,7 +126,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public bool StepFree { get; set; }
         public string ParentAssetIds { get; set; }
         public bool ContractIsApproved { get; set; }
-        public ApprovalStatus ContractApprovalStatus { get; set; }
+        public string ContractApprovalStatus { get; set; }
         public bool ContractIsActive { get; set; }
         public string ChargesSubType { get; set; }
         public bool TemporaryAccommodation { get; set; }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -124,7 +124,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public bool StepFree { get; set; }
         public string ParentAssetIds { get; set; }
         public bool ContractIsApproved { get; set; }
-        public ApprovalStatus ContractApprovalStatus { get; set;}        
+        public ApprovalStatus ContractApprovalStatus { get; set; }
         public bool ContractIsActive { get; set; }
         public string ChargesSubType { get; set; }
         public bool TemporaryAccommodation { get; set; }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -93,7 +93,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
                 UriKind.Relative);
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
-        }
+        }        
 
         public async Task WhenNoParameterIsProvided()
         {
@@ -262,7 +262,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.ApprovalStatus == contractApprovalStatus);
-        }
+        }        
         public async Task ThenAssetsWithProvidedContractStatusShouldBeIncluded(string contractStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -87,13 +87,13 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
 
-        public async Task WhenContractApprovalStatusIsProvided(ApprovalStatus approvalStatus)
+        public async Task WhenContractApprovalStatusIsProvided(string approvalStatus)
         {
             var route = new Uri($"api/v1/search/assets/all?contractApprovalStatus={approvalStatus}&page={1}",
                 UriKind.Relative);
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
-        }        
+        }
 
         public async Task WhenNoParameterIsProvided()
         {
@@ -255,14 +255,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.IsApproved == bool.Parse(contractApprovalStatus));
         }
-        public async Task ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(ApprovalStatus contractApprovalStatus, int expectedNumberOfAssets)
+        public async Task ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(string contractApprovalStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
 
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
-            result.Results.Assets.All(x => x.AssetContract.ApprovalStatus == contractApprovalStatus);
-        }        
+            result.Results.Assets.All(x => x.AssetContract.ApprovalStatus.ToString() == contractApprovalStatus);
+        }
         public async Task ThenAssetsWithProvidedContractStatusShouldBeIncluded(string contractStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps.Base;
 using HousingSearchApi.V1.Boundary.Responses;
@@ -85,6 +86,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
+
+        public async Task WhenContractApprovalStatusIsProvided(ApprovalStatus approvalStatus)
+        {
+            var route = new Uri($"api/v1/search/assets/all?contractApprovalStatus={approvalStatus}&page={1}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }        
 
         public async Task WhenNoParameterIsProvided()
         {
@@ -246,6 +255,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.IsApproved == bool.Parse(contractApprovalStatus));
         }
+        public async Task ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(ApprovalStatus contractApprovalStatus, int expectedNumberOfAssets)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
+            result.Results.Assets.All(x => x.AssetContract.ApprovalStatus == contractApprovalStatus);
+        }        
         public async Task ThenAssetsWithProvidedContractStatusShouldBeIncluded(string contractStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -93,7 +93,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
                 UriKind.Relative);
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
-        }        
+        }
 
         public async Task WhenNoParameterIsProvided()
         {
@@ -262,7 +262,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.ApprovalStatus == contractApprovalStatus);
-        }        
+        }
         public async Task ThenAssetsWithProvidedContractStatusShouldBeIncluded(string contractStatus, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -150,7 +150,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(approvedApprovalStatus))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 1))
                 .BDDfy();
-        }
+        }        
         [Fact]
         public void ServiceFiltersFalseContractIsApprovedStatusWithoutSearchText()
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -143,14 +143,32 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
         [Fact]
+        public void ServiceFiltersPendingApprovalStatusWithoutSearchText()
+        {
+            var pendingApprovalStatus = "0";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingApprovalStatus))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 3))
+                .BDDfy();
+        }
+        [Fact]
         public void ServiceFiltersApprovedApprovalStatusWithoutSearchText()
         {
-            ApprovalStatus approvedApprovalStatus = 0;
+            var approvedApprovalStatus = "1";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(approvedApprovalStatus))
-                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 1))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 2))
                 .BDDfy();
-        }        
+        }
+        [Fact]
+        public void ServiceFiltersPendingReapprovalStatusWithoutSearchText()
+        {
+            var pendingReapprovalApprovalStatus = "2";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingReapprovalApprovalStatus))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingReapprovalApprovalStatus, 8))
+                .BDDfy();
+        }
         [Fact]
         public void ServiceFiltersFalseContractIsApprovedStatusWithoutSearchText()
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -1,5 +1,6 @@
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -141,6 +142,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenAssetsWithContractApprovalStatusShouldBeIncluded(contractIsApproved, 2))
                 .BDDfy();
         }
+        [Fact]
+        public void ServiceFiltersApprovedApprovalStatusWithoutSearchText()
+        {
+            ApprovalStatus approvedApprovalStatus = 0;
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractApprovalStatusIsProvided(approvedApprovalStatus))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 1))
+                .BDDfy();
+        }        
         [Fact]
         public void ServiceFiltersFalseContractIsApprovedStatusWithoutSearchText()
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -150,7 +150,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(approvedApprovalStatus))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 1))
                 .BDDfy();
-        }        
+        }
         [Fact]
         public void ServiceFiltersFalseContractIsApprovedStatusWithoutSearchText()
         {

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.75.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.76.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -1,3 +1,4 @@
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HousingSearchApi.V1.Boundary.Requests
@@ -32,7 +33,7 @@ namespace HousingSearchApi.V1.Boundary.Requests
         public string ContractIsApproved { get; set; }
 
         [FromQuery(Name = "contractApprovalStatus")]
-        public string ContractApprovalStatus { get; set; }
+        public ApprovalStatus ContractApprovalStatus { get; set; }
 
         [FromQuery(Name = "contractIsActive")]
         public string ContractIsActive { get; set; }

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -33,7 +33,7 @@ namespace HousingSearchApi.V1.Boundary.Requests
         public string ContractIsApproved { get; set; }
 
         [FromQuery(Name = "contractApprovalStatus")]
-        public ApprovalStatus ContractApprovalStatus { get; set; }
+        public string ContractApprovalStatus { get; set; }
 
         [FromQuery(Name = "contractIsActive")]
         public string ContractIsActive { get; set; }

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -30,6 +30,10 @@ namespace HousingSearchApi.V1.Boundary.Requests
 
         [FromQuery(Name = "contractIsApproved")]
         public string ContractIsApproved { get; set; }
+
+        [FromQuery(Name = "contractApprovalStatus")]
+        public string ContractApprovalStatus { get; set; }
+
         [FromQuery(Name = "contractIsActive")]
         public string ContractIsActive { get; set; }
         [FromQuery(Name = "chargesSubType")]

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -113,6 +113,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
@@ -147,6 +148,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -113,7 +113,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
-                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus.ToString(), new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
@@ -148,7 +148,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
-                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus.ToString(), new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -148,7 +148,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
-                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus.ToString(), new List<string> { "assetContract.approvalStatus" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })

--- a/HousingSearchApi/V1/Interfaces/IFilterQueryBuilder.cs
+++ b/HousingSearchApi/V1/Interfaces/IFilterQueryBuilder.cs
@@ -1,4 +1,5 @@
 using Hackney.Core.ElasticSearch.Interfaces;
+using Hackney.Shared.HousingSearch.Domain.Enums;
 using Nest;
 using System.Collections.Generic;
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1610

## Describe this PR

### *What is the problem we're trying to solve*

BTA users want to be able to reset the contract approval status of an updated approved contract so that it can be submitted for reapproval. This calls for changing from a boolean value to an enum in the Contracts, to account for more than two possible statuses.
We haven't removed the `isApproved` flag yet so that the FE can continue to function until we introduce the new field there too.

### *What changes have we introduced*

New package version and introduction of new fields + tests (with all the fun connected to enums)
