### PR TITLE
Improve search v2

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -37,7 +37,7 @@ public class GetAssetStoriesV2 : IClassFixture<MockWebApplicationFactory<Startup
             }
         };
 
-        var assets = splitLines.Select(line => TryParse(line)?.RootElement).Where(x=>x != null);
+        var assets = splitLines.Select(line => TryParse(line)?.RootElement).Where(x => x != null);
         var jsonElements = assets as JsonElement?[] ?? assets.ToArray();
         var asset = jsonElements.ElementAt(new Random().Next(jsonElements.Count()));
         return (JsonElement) asset;

--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -12,18 +16,44 @@ public class GetAssetStoriesV2 : IClassFixture<MockWebApplicationFactory<Startup
     // Note: see assets.json for the data that is being searched
     private readonly HttpClient _httpClient;
 
+    // Return a random asset from the assets.json file
+    private JsonElement RandomAsset()
+    {
+        using StreamReader r = new StreamReader("V2/E2ETests/Fixtures/assets.json");
+        string json = r.ReadToEnd();
+        List<string> splitLines = new List<string>(json.Split("\n"))
+            .Where(line => !line.Contains("index")
+            ).ToList();
+
+        Func<string, JsonDocument> TryParse = str_json =>
+        {
+            try
+            {
+                return JsonDocument.Parse(str_json);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        };
+
+        var assets = splitLines.Select(line => TryParse(line)?.RootElement).Where(x=>x != null);
+        var jsonElements = assets as JsonElement?[] ?? assets.ToArray();
+        var asset = jsonElements.ElementAt(new Random().Next(jsonElements.Count()));
+        return (JsonElement) asset;
+    }
+
     public GetAssetStoriesV2(MockWebApplicationFactory<Startup> factory)
     {
         _httpClient = factory.CreateClient();
     }
 
-    private HttpRequestMessage CreateSearchRequest(string searchText)
-    {
-        return new HttpRequestMessage(
+    private HttpRequestMessage CreateSearchRequest(string searchText) =>
+        new HttpRequestMessage(
             HttpMethod.Get,
             $"http://localhost:3000/api/v2/search/assets/?searchText={searchText}"
             );
-    }
+
 
     private JsonElement GetResponseRootElement(HttpResponseMessage response)
     {
@@ -47,13 +77,80 @@ public class GetAssetStoriesV2 : IClassFixture<MockWebApplicationFactory<Startup
         root.GetProperty("total").GetInt32().Should().Be(0);
     }
 
-    [Theory]
-    [InlineData("Gge 7 Toby Crossroad", "71312edd-10c3-41cf-b298-b97cce0c0123")]
-    [InlineData("6 Philip Alley", "5a6067de-458c-40cb-93a3-d16fe39da12a")]
-    [InlineData("Room 3 2 Kevin Inlet", "b5e85565-6241-4dd2-8f1f-50d626b129f2")]
-    public async Task ReturnsRelevantResultFirstByAddress(string searchText, string expectedReturnedId)
+    [Fact]
+    public async Task ReturnsRelevantResultFirstByAddress()
+    {
+        foreach (var _ in Enumerable.Range(0, 10))
+        {
+            // Arrange
+            var randomAsset = RandomAsset();
+            var expectedReturnedId = randomAsset.GetProperty("id").GetString();
+            var request = CreateSearchRequest(randomAsset.GetProperty("assetAddress").GetProperty("addressLine1").GetString());
+
+            // Act
+            var response = await _httpClient.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var root = GetResponseRootElement(response);
+            root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
+            var firstResult = root.GetProperty("results").GetProperty("assets")[0];
+            firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+        }
+    }
+
+    [Fact]
+    public async Task ReturnsRelevantResultFirstByPostcode()
+    {
+        foreach (var _ in Enumerable.Range(0, 10))
+        {
+            // Arrange
+            var randomAsset = RandomAsset();
+            var searchTextPostcode = randomAsset.GetProperty("assetAddress").GetProperty("postCode").GetString();
+            var request = CreateSearchRequest(searchTextPostcode);
+
+            // Act
+            var response = await _httpClient.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var root = GetResponseRootElement(response);
+            root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
+            var firstResult = root.GetProperty("results").GetProperty("assets")[0];
+            firstResult.GetProperty("assetAddress").GetProperty("postCode").GetString().Should().Be(searchTextPostcode);
+        }
+    }
+
+    [Fact]
+    public async Task ReturnsRelevantResultFirstByAddressAndPostcode()
+    {
+        foreach (var _ in Enumerable.Range(0, 10))
+        {
+            // Arrange
+            var randomAsset = RandomAsset();
+            var expectedReturnedId = randomAsset.GetProperty("id").GetString();
+            var searchText = randomAsset.GetProperty("assetAddress").GetProperty("addressLine1").GetString() + " " + randomAsset.GetProperty("assetAddress").GetProperty("postCode").GetString();
+            var request = CreateSearchRequest(searchText);
+
+            // Act
+            var response = await _httpClient.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var root = GetResponseRootElement(response);
+            root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
+            var firstResult = root.GetProperty("results").GetProperty("assets")[0];
+            firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+        }
+    }
+
+    [Fact]
+    public async Task ReturnsRelevantResultFirstByPaymentRef()
     {
         // Arrange
+        var asset = RandomAsset();
+        var expectedReturnedId = asset.GetProperty("id").GetString();
+        var searchText = asset.GetProperty("tenure").GetProperty("paymentReference").GetString();
         var request = CreateSearchRequest(searchText);
 
         // Act
@@ -67,69 +164,13 @@ public class GetAssetStoriesV2 : IClassFixture<MockWebApplicationFactory<Startup
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
     }
 
-    [Theory]
-    [InlineData("NW1 3LF")]
-    [InlineData("L22 9BQ")]
-    [InlineData("PA3R 7JR")]
-    public async Task ReturnsRelevantResultFirstByPostcode(string searchTextPostcode)
+    [Fact]
+    public async Task ReturnsRelevantResultFirstByAssetId()
     {
         // Arrange
-        var request = CreateSearchRequest(searchTextPostcode);
-
-        // Act
-        var response = await _httpClient.SendAsync(request);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var root = GetResponseRootElement(response);
-        root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
-        var firstResult = root.GetProperty("results").GetProperty("assets")[0];
-        firstResult.GetProperty("assetAddress").GetProperty("postCode").GetString().Should().Be(searchTextPostcode);
-    }
-
-    [Theory]
-    [InlineData("Gge 7 Toby CA18", "71312edd-10c3-41cf-b298-b97cce0c0123")]
-    [InlineData("6 Philip Alley BH62 8DR", "5a6067de-458c-40cb-93a3-d16fe39da12a")]
-    [InlineData("Room 3 2 Kevin BR49 6LU", "b5e85565-6241-4dd2-8f1f-50d626b129f2")]
-    public async Task ReturnsRelevantResultFirstByAddressAndPostcode(string searchText, string expectedReturnedId)
-    {
-        // Arrange
-        var request = CreateSearchRequest(searchText);
-
-        // Act
-        var response = await _httpClient.SendAsync(request);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var root = GetResponseRootElement(response);
-        root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
-        var firstResult = root.GetProperty("results").GetProperty("assets")[0];
-        firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-    }
-
-    [Theory]
-    [InlineData("154455647", "1d3f9e8e-d380-441f-97bb-2d280aecb80f")]
-    public async Task ReturnsRelevantResultFirstByPaymentRef(string searchText, string expectedReturnedId)
-    {
-        // Arrange
-        var request = CreateSearchRequest(searchText);
-
-        // Act
-        var response = await _httpClient.SendAsync(request);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var root = GetResponseRootElement(response);
-        root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
-        var firstResult = root.GetProperty("results").GetProperty("assets")[0];
-        firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-    }
-
-    [Theory]
-    [InlineData("171623604", "9309e7d5-3d4b-4091-9fc5-6bd7c8e1a436")]
-    public async Task ReturnsRelevantResultFirstByAssetId(string searchText, string expectedReturnedId)
-    {
-        // Arrange
+        var asset = RandomAsset();
+        var expectedReturnedId = asset.GetProperty("id").GetString();
+        var searchText = asset.GetProperty("assetId").GetString();
         var request = CreateSearchRequest(searchText);
 
         // Act

--- a/HousingSearchApi/Properties/launchSettings.json
+++ b/HousingSearchApi/Properties/launchSettings.json
@@ -12,7 +12,8 @@
     "housing_search_api": {
       "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "LocalDevelopment"
+        "ASPNETCORE_ENVIRONMENT": "LocalDevelopment",
+        "ELASTICSEARCH_DOMAIN_URL": "http://localhost:9200"
       },
       "applicationUrl": "http://localhost:3000"
     },
@@ -25,7 +26,8 @@
       "applicationUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://+:3000;http://+:9200"
+        "ASPNETCORE_URLS": "http://+:3000;http://+:9200",
+        "ELASTICSEARCH_DOMAIN_URL": "https://localhost:9200"
       }
     }
   }

--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -22,6 +22,7 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
 
             var connectionSettings =
                 new ConnectionSettings(pool)
+                    // .ServerCertificateValidationCallback((sender, certificate, chain, sslPolicyErrors) => url == "https://localhost:9200") // For local connection to dev
                     .PrettyJson()
                     .ThrowExceptions()
                     .DisableDirectStreaming();

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -27,6 +27,7 @@ public class SearchGateway : ISearchGateway
                     )
                 )
             )
+            .MinScore(15)
             .Size(searchParams.PageSize)
             .From((searchParams.PageNumber - 1) * searchParams.PageSize)
             .TrackTotalHits()

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -1,7 +1,8 @@
-using HousingSearchApi.V2.Gateways.Interfaces;
-using Nest;
+using System;
 using System.Threading.Tasks;
 using HousingSearchApi.V2.Domain.DTOs;
+using HousingSearchApi.V2.Gateways.Interfaces;
+using Nest;
 
 namespace HousingSearchApi.V2.Gateways;
 
@@ -17,22 +18,48 @@ public class SearchGateway : ISearchGateway
     public async Task<SearchResponseDto> Search(string indexName, SearchParametersDto searchParams)
     {
         var searchResponse = await _elasticClient.SearchAsync<object>(s => s
-                .Index(indexName)
-                .Query(q => q
-                    .SimpleQueryString(qs => qs
-                        .Fields("*")
-                        .Query(searchParams.SearchText)
+            .Index(indexName)
+            .Query(q => q
+                .Bool(b => b
+                    .Should(
+                        MultiMatchSingleField(searchParams.SearchText, boost: 6),
+                        MultiMatchAcrossFields(searchParams.SearchText, boost: 2)
                     )
                 )
-                .Size(searchParams.PageSize)
-                .From((searchParams.PageNumber - 1) * searchParams.PageSize)
-                .TrackTotalHits(true)
+            )
+            .Size(searchParams.PageSize)
+            .From((searchParams.PageNumber - 1) * searchParams.PageSize)
+            .TrackTotalHits()
         );
 
         return new SearchResponseDto
         {
             Documents = searchResponse.Documents,
-            Total = searchResponse.HitsMetadata.Total.Value
+            Total = searchResponse.HitsMetadata.Total.Value,
         };
     }
+
+
+    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchSingleField(string searchText, double boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.BestFields) // High score if all terms are in the same field
+                .Operator(Operator.And) // All terms must be in the same field
+                .Fuzziness(Fuzziness.Auto) // Allow for some typos
+                .Boost(boost)
+            );
+
+
+    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchAcrossFields(string searchText, double boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.CrossFields) // High score if all terms are in any field
+                .Operator(Operator.Or) // Terms can be across fields
+                .Boost(boost)
+            );
+
 }


### PR DESCRIPTION
#238 worked great locally because my local test data only included `assetAddress` and `tenure` fields. In practice on development it performs terribly especially because it keeps matching door numbers to the `assetLocation.floorNumber` field,

This PR changes the search to prioritise matching multiple terms in the same field, so e.g. `12 pitcairn house` will return results which have all the terms `12` `pitcairn` and `house` in the same field, instead of the previous one which would return results with the most occurrences of each of `12` `pitcairn` and `house` across the whole record.

The query has been made into a `bool` type query which can contain any number of query components. I've split them out into functions with the idea being that we can tweak the boost to get better results, or can attach more modules as needed in future while still having a clear overview of the relative `boost` levels.

This is the part which boosts matches where multiple terms are in the same field:
```csharp
private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchSingleField(string searchText, double boost) =>
        should => should
            .MultiMatch(mm => mm
                .Fields("*")
                .Query(searchText)
                .Type(TextQueryType.BestFields) // High score if all terms are in the same field
                .Operator(Operator.And) // All terms must be in the same field
                .Fuzziness(Fuzziness.Auto) // Allow for some typos
                .Boost(boost)
            );
```

This part still allows some flexibility for including multiple fields in the search request, e.g. a mix of addressLine1 and postCode:
```csharp
private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchAcrossFields(string searchText, double boost) =>
        should => should
            .MultiMatch(mm => mm
                .Fields("*")
                .Query(searchText)
                .Type(TextQueryType.CrossFields) // High score if all terms are in any field
                .Operator(Operator.Or) // Terms can be across fields
                .Boost(boost)
            );
```