### PR TITLE
Tweak search V2 for frontend updates

### DIFF
--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -28,6 +28,10 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
                     .DisableDirectStreaming();
             var esClient = new ElasticClient(connectionSettings);
 
+            var pingResponse = esClient.Ping();
+            if (!pingResponse.IsValid)
+                throw new Exception($"Elasticsearch ping failed: {pingResponse.DebugInformation}");
+
             services.TryAddSingleton<IElasticClient>(esClient);
         }
     }

--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -28,10 +28,6 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
                     .DisableDirectStreaming();
             var esClient = new ElasticClient(connectionSettings);
 
-            var pingResponse = esClient.Ping();
-            if (!pingResponse.IsValid)
-                throw new Exception($"Elasticsearch ping failed: {pingResponse.DebugInformation}");
-
             services.TryAddSingleton<IElasticClient>(esClient);
         }
     }

--- a/HousingSearchApi/V2/Controllers/SearchController.cs
+++ b/HousingSearchApi/V2/Controllers/SearchController.cs
@@ -34,7 +34,7 @@ public class SearchController : Controller
             {
                 [indexName] = searchResults.Documents
             },
-            Total = searchResults.Documents.Count // This should become searchResults.Total when the frontend supports pagination
+            searchResults.Total
         };
 
         return new OkObjectResult(response);

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -27,11 +27,14 @@ public class SearchGateway : ISearchGateway
                     )
                 )
             )
-            .MinScore(15)
+            .MinScore(25)
             .Size(searchParams.PageSize)
             .From((searchParams.PageNumber - 1) * searchParams.PageSize)
             .TrackTotalHits()
         );
+
+        if (!searchResponse.IsValid)
+            throw new Exception($"Elasticsearch search failed: {searchResponse.DebugInformation}");
 
         return new SearchResponseDto
         {


### PR DESCRIPTION
Allow frontend to handle pagination in V2 properly by returning the true total amount of matches.

Other change:
- Throw an exception if there's an elasticsearch connection or configuration issue early, so that the exception message is relevant and located close to the failure point