### PR TITLE
Improve search flexibility for results with lower "uniqueness"

### DIFF
--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -23,11 +23,12 @@ public class SearchGateway : ISearchGateway
                 .Bool(b => b
                     .Should(
                         MultiMatchSingleField(searchParams.SearchText, boost: 6),
-                        MultiMatchAcrossFields(searchParams.SearchText, boost: 2)
+                        MultiMatchCrossFields(searchParams.SearchText, boost: 2),
+                        MultiMatchMostFields(searchParams.SearchText, boost: 2)
                     )
                 )
             )
-            .MinScore(25)
+            .MinScore(30)
             .Size(searchParams.PageSize)
             .From((searchParams.PageNumber - 1) * searchParams.PageSize)
             .TrackTotalHits()
@@ -43,27 +44,39 @@ public class SearchGateway : ISearchGateway
         };
     }
 
-
+    // Score for matching a single (best) field
     private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchSingleField(string searchText, double boost) =>
         should => should
             .MultiMatch(mm => mm
                 .Fields("*")
                 .Query(searchText)
-                .Type(TextQueryType.BestFields) // High score if all terms are in the same field
-                .Operator(Operator.And) // All terms must be in the same field
-                .Fuzziness(Fuzziness.Auto) // Allow for some typos
+                .Type(TextQueryType.BestFields)
+                .Operator(Operator.And)
+                .Fuzziness(Fuzziness.Auto)
                 .Boost(boost)
             );
 
 
-    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchAcrossFields(string searchText, double boost) =>
+    // Score for matching the combination of many fields
+    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchCrossFields(string searchText, double boost) =>
         should => should
             .MultiMatch(mm => mm
                 .Fields("*")
                 .Query(searchText)
-                .Type(TextQueryType.CrossFields) // High score if all terms are in any field
-                .Operator(Operator.Or) // Terms can be across fields
+                .Type(TextQueryType.CrossFields)
+                .Operator(Operator.Or)
                 .Boost(boost)
+                .Fuzziness(Fuzziness.Auto)
             );
 
+    // Score for matching a high number (quantity) of fields
+    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchMostFields(string searchText, double boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.MostFields)
+                .Operator(Operator.Or)
+                .Boost(boost)
+            );
 }

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -66,7 +66,6 @@ public class SearchGateway : ISearchGateway
                 .Type(TextQueryType.CrossFields)
                 .Operator(Operator.Or)
                 .Boost(boost)
-                .Fuzziness(Fuzziness.Auto)
             );
 
     // Score for matching a high number (quantity) of fields
@@ -78,5 +77,6 @@ public class SearchGateway : ISearchGateway
                 .Type(TextQueryType.MostFields)
                 .Operator(Operator.Or)
                 .Boost(boost)
+                .Fuzziness(Fuzziness.Auto)
             );
 }

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -76,7 +76,7 @@ public class SearchGateway : ISearchGateway
                 .Query(searchText)
                 .Type(TextQueryType.MostFields)
                 .Operator(Operator.Or)
-                .Boost(boost)
                 .Fuzziness(Fuzziness.Auto)
+                .Boost(boost)
             );
 }


### PR DESCRIPTION
Currently in Version 2 the search sometimes does not return results where there are too many results that are partially relevant to the query text. This is particularly relevant for searching for persons by title, first, and last name.

There are many people that would match each of those fields, so in some cases the `MultiMatch` with `CrossFields` is not going to give enough of a score to people with very common first and last names to get them returned in the results.

This PR adds another `MultiMatch` module with the `MostFields` query type - this gives higher scores to records which have many fields matching.

It is important to balance this carefully so as not to provide less relevant records when single fields do match, so the boost has been set to 2 - much lower than the 6 for `MultiMatchSingleField`. From local testing this seems to give reasonable results