### PR TITLE
Delete unneeded toString

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -152,6 +152,13 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
+        public async Task WhenUPRNIsPassedButIsTemporaryAccomodationIsNotPassed(string uprn)
+        {
+            var route = new Uri($"api/v1/search/assets/all?&searchText={uprn}&page={1}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
         public async Task WhenIsTemporaryAccomodationIsTrueAndSearchText(string searchText)
         {
             var route = new Uri($"api/v1/search/assets/all?isTemporaryAccomodation=true&searchText={searchText}&page={1}",
@@ -167,7 +174,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             result.Results.Assets.All(x => x.AssetManagement.IsTemporaryAccomodation == true);
         }
+        public async Task ThenAllResultsWithPassedUPRNShouldBeIncluded()
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Count.Should().Be(8);
+        }
         public async Task ThenTheReturningResultsShouldBeOfThatSize(int pageSize)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -241,6 +241,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
         [Fact]
+        public void ServiceReturnsTemporaryAccomodationResultsWhenisTemporaryAccommodationNotPassed()
+        {
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenUPRNIsPassedButIsTemporaryAccomodationIsNotPassed("10008234650"))
+                .Then(t => _steps.ThenAllResultsWithPassedUPRNShouldBeIncluded())
+                .BDDfy();
+        }
+        [Fact]
         public void ServiceReturnsTemporaryAccomodationResultAddressWhereWildstarDoubleMatch()
         // If a search is made for an address string with more than two values in the string, it should only return a match where both wildstar values are found. 
         {

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -113,7 +113,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ParentAssetId, new List<string> { "rootAsset" })
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
-                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus.ToString(), new List<string> { "assetContract.approvalStatus" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatusReason, new List<string> { "assetContract.approvalStatusReason" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })


### PR DESCRIPTION
## Link to JIRA ticket

Add a link to the JIRA ticket that the changes in this PR describe.

## Describe this PR

### *What is the problem we're trying to solve*
As part of this PR, there was an unneeded `ToString()` call, vestigial from when we were figuring out how to use a new `enum`. 
![image](https://github.com/user-attachments/assets/920827d0-b3a4-47b3-9382-05684d8e4144)

This didn't cause any issue with the existing and new tests, so it went unnoticed. But when that parameter was passed empty within a call, the API got upset and threw an exception.
This PR aims to amend that.

### *What changes have we introduced*

Deleted unneeded `ToString()` and one more test.
