### PR TITLE
Reduce most fields boost to improve uprn search

### DIFF
--- a/HousingSearchApi/Properties/launchSettings.json
+++ b/HousingSearchApi/Properties/launchSettings.json
@@ -17,18 +17,13 @@
       },
       "applicationUrl": "http://localhost:3000"
     },
-    "Docker": {
-      "commandName": "Docker",
-      "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/api/v1/healthcheck/ping",
-      "httpPort": 3000,
-      "useSSL": false,
-      "applicationUrl": "http://localhost:3000",
+    "dev_database": {
+      "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://+:3000;http://+:9200",
+        "ASPNETCORE_ENVIRONMENT": "LocalDevelopment",
         "ELASTICSEARCH_DOMAIN_URL": "https://localhost:9200"
-      }
+      },
+      "applicationUrl": "http://localhost:3000"
     }
   }
 }

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -24,11 +24,11 @@ public class SearchGateway : ISearchGateway
                     .Should(
                         MultiMatchSingleField(searchParams.SearchText, boost: 6),
                         MultiMatchCrossFields(searchParams.SearchText, boost: 2),
-                        MultiMatchMostFields(searchParams.SearchText, boost: 2)
+                        MultiMatchMostFields(searchParams.SearchText, boost: 1)
                     )
                 )
             )
-            .MinScore(30)
+            .MinScore(25)
             .Size(searchParams.PageSize)
             .From((searchParams.PageNumber - 1) * searchParams.PageSize)
             .TrackTotalHits()


### PR DESCRIPTION
UPRN search was returning unrelated results first because the `MultiMatchMostFields` was beating the `MultiMatchSingleField` with some partial matches. This is ultimately an issue with how our Elasticsearch database is configured, but to make the most of what we've got we can reduce the boost for `MultiMatchMostFields` so it still improves person search flexibility without compromising UPRN search.

The min score has been reduced to prevent issues relating to persons not meeting the minimum threshold now that the `MultiMatchMostFields` boost has been reduced