### PR TITLE
Allow sorting by ID using simplified elasticsearch configuration

### DIFF
--- a/HousingSearchApi/V1/Controllers/GetAssetListController.cs
+++ b/HousingSearchApi/V1/Controllers/GetAssetListController.cs
@@ -74,22 +74,14 @@ namespace HousingSearchApi.V1.Controllers
         [LogCall(Microsoft.Extensions.Logging.LogLevel.Information)]
         public async Task<IActionResult> GetAllAssetList([FromQuery] GetAllAssetListRequest request)
         {
-            try
+            var assetsSearchResult = await _getAssetListSetsUseCase.ExecuteAsync(request).ConfigureAwait(false);
+            var apiResponse = new APIAllResponse<GetAllAssetListResponse>(assetsSearchResult)
             {
-                var assetsSearchResult = await _getAssetListSetsUseCase.ExecuteAsync(request).ConfigureAwait(false);
-                var apiResponse = new APIAllResponse<GetAllAssetListResponse>(assetsSearchResult)
-                {
-                    Total = assetsSearchResult.Total(),
-                    LastHitId = assetsSearchResult.LastHitId()
-                };
+                Total = assetsSearchResult.Total(),
+                LastHitId = assetsSearchResult.LastHitId()
+            };
 
-                return new OkObjectResult(apiResponse);
-            }
-            catch (Exception e)
-            {
-                LambdaLogger.Log(e.Message + e.StackTrace);
-                return new BadRequestObjectResult(e.Message);
-            }
+            return new OkObjectResult(apiResponse);
         }
     }
 }

--- a/HousingSearchApi/V1/Interfaces/Sorting/AssetIdAsc.cs
+++ b/HousingSearchApi/V1/Interfaces/Sorting/AssetIdAsc.cs
@@ -8,7 +8,7 @@ namespace HousingSearchApi.V1.Interfaces.Sorting
         public SortDescriptor<QueryableAsset> GetSortDescriptor(SortDescriptor<QueryableAsset> descriptor)
         {
             return descriptor
-                .Ascending(f => f.Id.Suffix("keyword"));
+                .Ascending(f => f.Id);
         }
     }
 }

--- a/HousingSearchApi/V1/Interfaces/Sorting/AssetIdDesc.cs
+++ b/HousingSearchApi/V1/Interfaces/Sorting/AssetIdDesc.cs
@@ -8,7 +8,7 @@ namespace HousingSearchApi.V1.Interfaces.Sorting
         public SortDescriptor<QueryableAsset> GetSortDescriptor(SortDescriptor<QueryableAsset> descriptor)
         {
             return descriptor
-                .Descending(f => f.Id.Suffix("keyword"));
+                .Descending(f => f.Id);
         }
     }
 }


### PR DESCRIPTION
After applying the production elasticsearch configuration on dev which was modified to reduce redundancy, that ended up breaking "sort by ID" in the get all assets response.

This is because the API specifically looks for the `keyword` subfield on the ID, which no longer exists. The new elasticsearch configuration has ID as a keyword by default because we don't want to support partial / fuzzy matching on ID fields.

Removing `.keyword` from the sort seems to fix the issue from local testing