### PR TITLE
Fix pagination in api v2

### DIFF
--- a/HousingSearchApi/V2/Controllers/SearchController.cs
+++ b/HousingSearchApi/V2/Controllers/SearchController.cs
@@ -1,7 +1,5 @@
-using Amazon.Lambda.Core;
 using Hackney.Core.Logging;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using HousingSearchApi.V2.Domain.DTOs;

--- a/HousingSearchApi/V2/Domain/DTOs/SearchParametersDto.cs
+++ b/HousingSearchApi/V2/Domain/DTOs/SearchParametersDto.cs
@@ -10,8 +10,8 @@ public class SearchParametersDto
     [FromQuery(Name = "pageSize")]
     public int PageSize { get; set; } = 120;
 
-    [FromQuery(Name = "pageNumber")]
-    public int PageNumber { get; set; } = 1;
+    [FromQuery(Name = "page")]
+    public int Page { get; set; } = 1;
 }
 
 

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -30,7 +30,7 @@ public class SearchGateway : ISearchGateway
             )
             .MinScore(25)
             .Size(searchParams.PageSize)
-            .From((searchParams.PageNumber - 1) * searchParams.PageSize)
+            .From((searchParams.Page - 1) * searchParams.PageSize)
             .TrackTotalHits()
         );
 


### PR DESCRIPTION
Annoying this wasn't caught in earlier testing - the API had "pageNumber" as a url parameter when it should be "page"