### PR TITLE
TS-1614: Adding data about the end of an assetContract

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -21,7 +21,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractIsApproved = false, ContractApprovalStatus = "PendingApproval", ChargesSubType="rate"},
+                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = false, ContractIsApproved = false, ContractApprovalStatus = "PendingReapproval", ContractEndReason="ContractHasEnded", ChargesSubType="rate"},
             new AddressStub{ FirstLine = "19 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234699",
                 AssetStatus = "Reserved", NoOfBedSpaces = 1, NoOfCots = 1, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractApprovalStatus = "PendingApproval", ContractIsApproved = false },
             new AddressStub{ FirstLine = "38 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234611",
@@ -100,6 +100,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 asset.AssetCharacteristics.IsStepFree = value.StepFree;
                 asset.ParentAssetIds = value.ParentAssetIds;
                 asset.AssetContract.IsApproved = value.ContractIsApproved;
+                asset.AssetContract.EndReason = value.ContractEndReason;
                 asset.AssetContract.ApprovalStatus = parsedApprovalStatus;
                 asset.AssetContract.ApprovalStatusReason = value.ContractApprovalStatusReason;
                 asset.AssetContract.IsActive = value.ContractIsActive;
@@ -130,6 +131,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public string ContractApprovalStatus { get; set; }
         public string ContractApprovalStatusReason { get; set; }
         public bool ContractIsActive { get; set; }
+        public string ContractEndReason { get; set; }
         public string ChargesSubType { get; set; }
         public bool TemporaryAccommodation { get; set; }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -116,6 +116,13 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
+        public async Task WhenContractEndReasonIsProvided(string contractEndReason)
+        {
+            var route = new Uri($"api/v1/search/assets/all?contractEndReason={contractEndReason}&page={1}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
         public async Task WhenAssetContractSubtypeIsProvided(string chargesSubtype)
         {
             var route = new Uri($"api/v1/search/assets/all?ChargesSubtype={chargesSubtype}&page={1}",
@@ -299,6 +306,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContract.IsActive == bool.Parse(contractStatus));
+        }
+        public async Task ThenAssetsWithProvidedEndReasonShouldBeIncluded(string contractEndReason, int expectedNumberOfAssets)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
+            result.Results.Assets.All(x => x.AssetContract.EndReason == contractEndReason);
         }
         public async Task ThenAssetsWhoseContractHasProvidedChargesSubytpeAreReturned(string chargesSubtype, int expectedNumberOfAssets)
         {

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -148,7 +148,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var pendingApprovalStatus = "0";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingApprovalStatus))
-                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 3))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 2))
                 .BDDfy();
         }
         [Fact]
@@ -166,7 +166,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var pendingReapprovalApprovalStatus = "2";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingReapprovalApprovalStatus))
-                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingReapprovalApprovalStatus, 8))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingReapprovalApprovalStatus, 9))
                 .BDDfy();
         }
         [Fact]
@@ -203,7 +203,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsActive = "true";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsActive, 12))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsActive, 11))
                 .BDDfy();
         }
         [Fact]
@@ -221,7 +221,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsNotActive = "false";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsNotActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 1))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 2))
+                .BDDfy();
+        }
+        [Fact]
+        public void ServiceFiltersContractEndReason()
+        {
+            var contractEndReason = "ContractHasEnded";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractEndReasonIsProvided(contractEndReason))
+                .Then(t => _steps.ThenAssetsWithProvidedEndReasonShouldBeIncluded(contractEndReason, 1))
                 .BDDfy();
         }
         [Fact]

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.78.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.79.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -41,6 +41,9 @@ namespace HousingSearchApi.V1.Boundary.Requests
         [FromQuery(Name = "contractIsActive")]
         public string ContractIsActive { get; set; }
 
+        [FromQuery(Name = "contractEndReason")]
+        public string ContractEndReason { get; set; }
+
         [FromQuery(Name = "chargesSubType")]
         public string ChargesSubType { get; set; }
         [FromQuery(Name = "isTemporaryAccomodation")]

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -115,6 +115,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsApproved, new List<string> { "assetContract.isApproved" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractEndReason, new List<string> { "assetContract.endReason" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatusReason, new List<string> { "assetContract.approvalStatusReason" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithWildstarQuery(assetListAllRequest.SearchText,
@@ -152,6 +153,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatus, new List<string> { "assetContract.approvalStatus" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractApprovalStatusReason, new List<string> { "assetContract.approvalStatusReason" })
                         .WithMultipleFilterQuery(assetListAllRequest.ContractIsActive, new List<string> { "assetContract.isActive" })
+                        .WithMultipleFilterQuery(assetListAllRequest.ContractEndReason, new List<string> { "assetContract.endReason" })
                         .WithMultipleFilterQuery(assetListAllRequest.ChargesSubType, new List<string> { "assetContract.charges.subType" })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })
                         .WithFilterQuery(assetListAllRequest.AssetStatus, new List<string> { "assetManagement.propertyOccupiedStatus" })


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1614

## Describe this PR

### *What is the problem we're trying to solve*

BTA users need a way to cancel invalid contracts (contracts opened in error) so that approval will no longer be required and no payment will be made to agent/landlord.
To do so, we need to see data about when and why a Contract was ended in the Asset information, as it will inform the decision about display a Contract for approval on BTA.

### *What changes have we introduced*

Shared package version update, query generator and boundary, updated tests (setting one more contract to `ContractIsActive=false` jazzed tests up).