### PR TITLE
Update V2 based on comparisons with V1

### DIFF
--- a/HousingSearchApi/V2/Controllers/SearchController.cs
+++ b/HousingSearchApi/V2/Controllers/SearchController.cs
@@ -25,13 +25,6 @@ public class SearchController : Controller
     [HttpGet("{indexName}")]
     public async Task<IActionResult> Search(string indexName, [FromQuery] SearchParametersDto searchParametersDto)
     {
-        var useSearchV1 = Environment.GetEnvironmentVariable("USE_SEARCH_V1") ?? "false";
-        if (useSearchV1 == "true")
-        {
-            var redirectUrl = $"/api/v1/search/{indexName}{Request.QueryString}";
-            return new RedirectResult(redirectUrl, permanent: false);
-        }
-
         var searchResults = await _searchUseCase.ExecuteAsync(indexName, searchParametersDto).ConfigureAwait(false);
 
         var response = new

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using HousingSearchApi.V2.Domain.DTOs;
 using HousingSearchApi.V2.Gateways.Interfaces;
@@ -17,26 +18,55 @@ public class SearchGateway : ISearchGateway
 
     public async Task<SearchResponseDto> Search(string indexName, SearchParametersDto searchParams)
     {
-        string addressSearchFieldName;
+        var shouldOperations = new List<Func<QueryContainerDescriptor<object>, QueryContainer>>();
+        var defaultShouldOperations = new[]
+        {
+            SearchOperations.MultiMatchSingleField(searchParams.SearchText, boost: 6),
+            SearchOperations.MultiMatchCrossFields(searchParams.SearchText, boost: 2),
+            SearchOperations.MultiMatchMostFields(searchParams.SearchText, boost: 1)
+        };
+
         if (indexName == "assets")
-            addressSearchFieldName = "assetAddress.addressLine1";
+        {
+            var addressFieldName = "assetAddress.addressLine1";
+            shouldOperations.AddRange(new[]
+            {
+                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, fieldName: addressFieldName, boost: 10),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fieldName: addressFieldName, boost: 5),
+            });
+            shouldOperations.AddRange(defaultShouldOperations);
+        }
         else if (indexName == "tenures")
-            addressSearchFieldName = "tenuredAsset.fullAddress";
+        {
+            var addressFieldName = "tenuredAsset.fullAddress";
+            var nameFields = new List<string> { "householdMembers.fullName" };
+            shouldOperations
+            .AddRange(new[]
+            {
+                SearchOperations.SearchWithWildcardQuery(searchParams.SearchText, boost: 10, fields: nameFields),
+                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, fieldName: addressFieldName, boost: 10),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fieldName: addressFieldName, boost: 5),
+            });
+            shouldOperations.AddRange(defaultShouldOperations);
+        }
         else if (indexName == "persons")
-            addressSearchFieldName = "tenures.assetFullAddress";
-        else
-            throw new Exception($"Index name '{indexName}' is not supported");
+        {
+            var nameFields = new List<string> { "firstname", "surname" };
+            shouldOperations.AddRange(new[]
+            {
+                SearchOperations.SearchWithWildcardQuery(searchParams.SearchText, boost: 10, fields: nameFields),
+                SearchOperations.SearchWithExactQuery(searchParams.SearchText, boost: 6, fields: nameFields),
+            });
+        }
+        else // default
+            shouldOperations.AddRange(defaultShouldOperations);
+
 
         var searchResponse = await _elasticClient.SearchAsync<object>(s => s
             .Index(indexName)
             .Query(q => q
                 .Bool(b => b
-                    .Should(
-                        MatchPhrasePrefix(searchParams.SearchText, boost: 10, fieldName: addressSearchFieldName),
-                        MultiMatchSingleField(searchParams.SearchText, boost: 6),
-                        MultiMatchCrossFields(searchParams.SearchText, boost: 2),
-                        MultiMatchMostFields(searchParams.SearchText, boost: 1)
-                    )
+                    .Should(shouldOperations)
                 )
             )
             .MinScore(25)
@@ -54,51 +84,4 @@ public class SearchGateway : ISearchGateway
             Total = searchResponse.HitsMetadata.Total.Value,
         };
     }
-
-    // Score for matching a value which starts with the search text
-    private Func<QueryContainerDescriptor<object>, QueryContainer>
-        MatchPhrasePrefix(string searchText, double boost, string fieldName) =>
-        should => should
-            .MatchPhrasePrefix(mp => mp
-                .Field(fieldName)
-                .Query(searchText)
-                .Boost(boost)
-            );
-
-    // Score for matching a single (best) field
-    private Func<QueryContainerDescriptor<object>, QueryContainer>
-        MultiMatchSingleField(string searchText, double boost) =>
-        should => should
-            .MultiMatch(mm => mm
-                .Fields("*")
-                .Query(searchText)
-                .Type(TextQueryType.BestFields)
-                .Operator(Operator.And)
-                .Fuzziness(Fuzziness.Auto)
-                .Boost(boost)
-            );
-
-    // Score for matching the combination of many fields
-    private Func<QueryContainerDescriptor<object>, QueryContainer>
-        MultiMatchCrossFields(string searchText, double boost) =>
-        should => should
-            .MultiMatch(mm => mm
-                .Fields("*")
-                .Query(searchText)
-                .Type(TextQueryType.CrossFields)
-                .Operator(Operator.Or)
-                .Boost(boost)
-            );
-
-    // Score for matching a high number (quantity) of fields
-    private Func<QueryContainerDescriptor<object>, QueryContainer> MultiMatchMostFields(string searchText, double boost) =>
-        should => should
-            .MultiMatch(mm => mm
-                .Fields("*")
-                .Query(searchText)
-                .Type(TextQueryType.MostFields)
-                .Operator(Operator.Or)
-                .Fuzziness(Fuzziness.Auto)
-                .Boost(boost)
-            );
 }

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -43,7 +43,7 @@ public class SearchGateway : ISearchGateway
             shouldOperations
             .AddRange(new[]
             {
-                SearchOperations.SearchWithWildcardQuery(searchParams.SearchText, boost: 10, fields: nameFields),
+                SearchOperations.SearchWithWildcardQuery(searchParams.SearchText, fields: nameFields, boost: 10),
                 SearchOperations.MatchPhrasePrefix(searchParams.SearchText, fieldName: addressFieldName, boost: 10),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fieldName: addressFieldName, boost: 5),
             });

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -43,8 +43,7 @@ public class SearchGateway : ISearchGateway
         {
             var addressFieldName = "tenuredAsset.fullAddress";
             var nameFields = new List<string> { "householdMembers.fullName" };
-            shouldOperations
-            .AddRange(new[]
+            shouldOperations.AddRange(new[]
             {
                 SearchOperations.SearchWithWildcardQuery(searchParams.SearchText, fields: nameFields, boost: 10),
                 SearchOperations.MatchPhrasePrefix(searchParams.SearchText, fieldName: addressFieldName, boost: 10),

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -1,0 +1,134 @@
+using Nest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace HousingSearchApi.V2.Gateways;
+
+
+class SearchOperations
+{
+    // TODO: Do we need separate wildcard functions?
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+    SearchWithWildcardQuery(string searchText, List<string> fields, int boost)
+    {
+        List<string> ProcessWildcards(string phrase)
+        {
+            if (string.IsNullOrEmpty(phrase))
+                return new List<string>();
+            return phrase.Split(' ').Select(word => $"*{word}*").ToList();
+        }
+
+        var listOfWildcardedWords = ProcessWildcards(searchText);
+        var queryString = $"({string.Join(" AND ", listOfWildcardedWords)}) " + string.Join(" ", listOfWildcardedWords);
+
+        return q => q.QueryString(qs => qs
+            .Query(queryString)
+            .Fields(fields.Select(f => (Field) f).ToArray())
+            .DefaultOperator(Operator.And)
+            .Boost(boost)
+        );
+    }
+
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+    SearchWithExactQuery(string searchText, List<string> fields, int boost)
+    {
+        string Process(string searchText)
+        {
+            searchText = searchText.Trim();
+            if (searchText.Split(' ').Length == 2)
+                return searchText.Replace(" ", " AND ");
+            return searchText;
+        }
+
+        var processedQuery = Process(searchText);
+
+        return q => q.QueryString(qs => qs
+            .Query(processedQuery)
+            .Fields(fields.Select(f => (Field) $"{f}^{boost}").ToArray())
+            .DefaultOperator(Operator.And)
+        );
+    }
+
+    // Score for matching a value which starts with the search text
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MatchPhrasePrefix(string searchText, string fieldName, int boost) =>
+        should => should
+            .MatchPhrasePrefix(mp => mp
+                .Field(fieldName)
+                .Query(searchText)
+                .Boost(boost)
+            );
+
+    // Score for matching a single (best) field
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MultiMatchSingleField(string searchText, int boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.BestFields)
+                .Operator(Operator.And)
+                .Fuzziness(Fuzziness.Auto)
+                .Boost(boost)
+            );
+
+    // Score for matching the combination of many fields
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MultiMatchCrossFields(string searchText, int boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.CrossFields)
+                .Operator(Operator.Or)
+                .Boost(boost)
+            );
+
+    // Score for matching a high number (quantity) of fields
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MultiMatchMostFields(string searchText, int boost) =>
+        should => should
+            .MultiMatch(mm => mm
+                .Fields("*")
+                .Query(searchText)
+                .Type(TextQueryType.MostFields)
+                .Operator(Operator.Or)
+                .Fuzziness(Fuzziness.Auto)
+                .Boost(boost)
+            );
+
+
+    // Score for matching a value which contains the search text
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        WildcardMatch(string searchText, string fieldName, int boost)
+    {
+        List<string> ProcessWildcards(string phrase)
+        {
+            if (string.IsNullOrEmpty(phrase))
+                return new List<string>();
+            return phrase.Split(' ').Select(word => $"*{word}*").ToList();
+        }
+
+        var listOfWildcardedWords = ProcessWildcards(searchText);
+        var wildcardQueries = listOfWildcardedWords.Select(term => new WildcardQuery
+        {
+            Field = fieldName,
+            Value = $"*{term}*",
+            Boost = boost
+        }).ToList();
+
+        return q => q.Bool(b => b
+            .Should(wildcardQueries.Select(wq => 
+                new QueryContainerDescriptor<object>()
+                    .Wildcard(w => w
+                        .Field(wq.Field)
+                        .Value(wq.Value)
+                        .Boost(wq.Boost)
+                    )
+                ).ToArray()
+            )
+        );
+    }
+}

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -120,7 +120,7 @@ class SearchOperations
         }).ToList();
 
         return q => q.Bool(b => b
-            .Should(wildcardQueries.Select(wq => 
+            .Should(wildcardQueries.Select(wq =>
                 new QueryContainerDescriptor<object>()
                     .Wildcard(w => w
                         .Field(wq.Field)

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -9,7 +9,6 @@ namespace HousingSearchApi.V2.Gateways;
 
 class SearchOperations
 {
-    // TODO: Do we need separate wildcard functions?
     public static Func<QueryContainerDescriptor<object>, QueryContainer>
     SearchWithWildcardQuery(string searchText, List<string> fields, int boost)
     {


### PR DESCRIPTION
## Separate logic for asset, tenure, and person search

The defaults from V2 have been kept, but they are extended for asset, tenure, and person search so that they can work "at least as well as V1" in all the same cases - at least that's the goal.

The new additions were mainly copied from Search V1 because that already had workarounds for our imperfect Elasticsearch data mapping settings. If we make some improvements to the settings then perhaps these workarounds can be removed but for now this is the shortest path to getting search working "as well as V1" in most areas but still providing improvements in other areas.

### All (default):
(same as before in V2 - allows rudimentary search on any field in any model)
- Score items where a single field strongly matches the search term
- Score items where the search term matches across multiple fields
- Score items where the search term matches a high number of fields at the same time

### Asset search:
- Match a prefix on the `assetAddress.addressLine1` field to allow e.g. "12 pit" to match "12 Pitcairn House..."
- Wildcard match on the `assetAddress.addressLine1` field to allow gaps in the address, e.g. "5 Sandgate House" to match "FLAT 5 Sandgate House"

### Tenure search:
- Match prefix and wildcard as above, on the `tenuredAsset.fullAddress` field
- Match wildcards for each item in the search text separated by space on the `householdMembers.fullName` field (i.e. allow matching names that partially match the search term)

### Person search:
The reason this wasn't working well is because again `firstname` and `lastname` are keyword fields which are not intended for partial matching, hence we have to use the workarounds in V1 for now. We should update the production person settings when possible. This was fixed by copying the V1 functionality (with a few layers of abstraction removed):
- Match wildcards for each item in the search text separated by space on the `firstname` and `lastname` fields (identical functionality to search V1)
- Match exact matches between the search terms and the `firstname` and `lastname` fields (identical with search V1)

## Other changes:
Search operations pulled into separate file for tidier overview