### PR TITLE
TS-1746: BTA - Change package version so ApprovalStatus is a string

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading;
 using AutoFixture;
 using Elasticsearch.Net;
-using Hackney.Shared.HousingSearch.Domain.Enums;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Persons;
@@ -85,7 +84,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             {
                 var asset = fixture.Create<QueryableAsset>();
                 var chargeWithSetSubtype = fixture.Create<QueryableCharges>();
-                var parsedApprovalStatus = (ApprovalStatus) Enum.Parse(typeof(ApprovalStatus), value.ContractApprovalStatus);
+                var parsedApprovalStatus = value.ContractApprovalStatus;
                 chargeWithSetSubtype.SubType = value.ChargesSubType;
                 asset.AssetAddress.AddressLine1 = value.FirstLine;
                 asset.AssetType = value.AssetType;

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Hackney.Shared.HousingSearch.Domain.Enums;
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps.Base;
 using HousingSearchApi.V1.Boundary.Responses;

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -1,6 +1,5 @@
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps;
-using Hackney.Shared.HousingSearch.Domain.Enums;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -145,7 +144,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceFiltersPendingApprovalStatusWithoutSearchText()
         {
-            var pendingApprovalStatus = "0";
+            var pendingApprovalStatus = "PendingApproval";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingApprovalStatus))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 2))
@@ -154,7 +153,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceFiltersApprovedApprovalStatusWithoutSearchText()
         {
-            var approvedApprovalStatus = "1";
+            var approvedApprovalStatus = "Approved";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(approvedApprovalStatus))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(approvedApprovalStatus, 2))
@@ -163,7 +162,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceFiltersPendingReapprovalStatusWithoutSearchText()
         {
-            var pendingReapprovalApprovalStatus = "2";
+            var pendingReapprovalApprovalStatus = "PendingReapproval";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingReapprovalApprovalStatus))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingReapprovalApprovalStatus, 9))

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.79.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.80.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -1,4 +1,3 @@
-using Hackney.Shared.HousingSearch.Domain.Enums;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HousingSearchApi.V1.Boundary.Requests

--- a/HousingSearchApi/V1/Interfaces/IFilterQueryBuilder.cs
+++ b/HousingSearchApi/V1/Interfaces/IFilterQueryBuilder.cs
@@ -1,5 +1,4 @@
 using Hackney.Core.ElasticSearch.Interfaces;
-using Hackney.Shared.HousingSearch.Domain.Enums;
 using Nest;
 using System.Collections.Generic;
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1746

## Describe this PR

### *What is the problem we're trying to solve*

We need for ApprovalStatus to be set as a string in the Housing Search world to avoid de/serialisation issues and receive it as a string (as opposed to the current integer) in the Housing Search API response

### *What changes have we introduced*

Upgraded package version, tests, deleted unnecessary using statements and parsing.