### PR TITLE
Create indexes from definitions in V2 tests

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -40,35 +40,27 @@ public class ElasticsearchFixture : IAsyncLifetime
     {
         string jsonFilePath = Path.Combine(FixtureFilesPath, filename);
         if (!File.Exists(jsonFilePath))
-        {
             throw new FileNotFoundException($"The file {jsonFilePath} could not be found in directory {Directory.GetCurrentDirectory()}");
-        }
+
 
         string jsonContent = await File.ReadAllTextAsync(jsonFilePath);
 
         var bulkResponse = await Client.LowLevel.BulkAsync<StringResponse>(PostData.String(jsonContent));
 
         if (!bulkResponse.Success)
-        {
             throw new Exception("Bulk insert failed: " + bulkResponse.DebugInformation);
-        }
+
     }
 
     public async Task InitializeAsync()
     {
         var indexSettingsFiles = new string[] { "assetIndex.json", "tenureIndex.json", "personIndex.json" };
-
         foreach (string filename in indexSettingsFiles)
-        {
             await CreateIndexAsync(filename, indexName: filename.Replace("Index.json", ""));
-        }
 
-        string[] filenames = { "assets.json", "tenures.json", "persons.json" };
-
+        var filenames = new string[] { "assets.json", "tenures.json", "persons.json" };
         foreach (string filename in filenames)
-        {
             await LoadDataAsync(filename);
-        }
     }
 
     public Task DisposeAsync()

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Xunit;
+using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace HousingSearchApi.Tests.V2.E2ETests.Fixtures;
 
@@ -12,35 +14,65 @@ public class ElasticsearchFixture : IAsyncLifetime
     public IElasticClient Client { get; private set; }
     public string FixtureFilesPath = "V2/E2ETests/Fixtures/Files";
 
+    private string _indexFilesPath => "data/elasticsearch";
+
     public ElasticsearchFixture()
     {
         var url = Environment.GetEnvironmentVariable("ELASTICSEARCH_DOMAIN_URL") ?? "http://localhost:9200";
-        var settings = new ConnectionSettings(new Uri(url))
-            .DefaultIndex("assets");
-
+        var settings = new ConnectionSettings(new Uri(url));
         Client = new ElasticClient(settings);
+    }
+
+    public async Task CreateIndexAsync(string filename, string indexName)
+    {
+        var indexraw = await File.ReadAllTextAsync(Path.Combine(_indexFilesPath, filename));
+        var index = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(indexraw);
+
+        var createIndexResponse = await Client.Indices.CreateAsync(indexName, c => c
+            .InitializeUsing(new IndexState
+            {
+                Settings = new IndexSettings(index["mappings"])
+            })
+        );
+
+        if (!createIndexResponse.IsValid)
+        {
+            throw new Exception("Index creation failed: " + createIndexResponse.DebugInformation);
+        }
+    }
+
+    public async Task LoadDataAsync(string filename)
+    {
+        string jsonFilePath = Path.Combine(FixtureFilesPath, filename);
+        if (!File.Exists(jsonFilePath))
+        {
+            throw new FileNotFoundException($"The file {jsonFilePath} could not be found in directory {Directory.GetCurrentDirectory()}");
+        }
+
+        string jsonContent = await File.ReadAllTextAsync(jsonFilePath);
+
+        var bulkResponse = await Client.LowLevel.BulkAsync<StringResponse>(PostData.String(jsonContent));
+
+        if (!bulkResponse.Success)
+        {
+            throw new Exception("Bulk insert failed: " + bulkResponse.DebugInformation);
+        }
     }
 
     public async Task InitializeAsync()
     {
+        var indexSettingsFiles = new string[] { "assetIndex.json", "tenureIndex.json", "personIndex.json" };
+
+        foreach (string filename in indexSettingsFiles)
+        {
+            await CreateIndexAsync(filename, indexName: filename.Replace("Index.json", ""));
+        }
+
         string[] filenames = { "assets.json", "tenures.json", "persons.json" };
 
         foreach (string filename in filenames)
         {
-            string jsonFilePath = Path.Combine(FixtureFilesPath, filename);
-            if (!File.Exists(jsonFilePath))
-            {
-                throw new FileNotFoundException($"The file {jsonFilePath} could not be found in directory {Directory.GetCurrentDirectory()}");
-            }
-
-            string jsonContent = await File.ReadAllTextAsync(jsonFilePath);
-
-            var bulkResponse = await Client.LowLevel.BulkAsync<StringResponse>(PostData.String(jsonContent));
-
-            if (!bulkResponse.Success)
-            {
-                throw new Exception("Bulk insert failed: " + bulkResponse.DebugInformation);
-            }
+            await LoadDataAsync(filename);
         }
     }
 

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -4,8 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Xunit;
-using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace HousingSearchApi.Tests.V2.E2ETests.Fixtures;
 
@@ -25,10 +23,10 @@ public class ElasticsearchFixture : IAsyncLifetime
 
     public async Task CreateIndexAsync(string filename, string indexName)
     {
-        var indexRaw = await File.ReadAllTextAsync(Path.Combine(_indexFilesPath, filename));
+        var indexDefinition = await File.ReadAllTextAsync(Path.Combine(_indexFilesPath, filename));
         var client = new ElasticClient();
 
-        var response = await client.LowLevel.Indices.CreateAsync<StringResponse>(indexName, indexRaw);
+        var response = await client.LowLevel.Indices.CreateAsync<StringResponse>(indexName, indexDefinition);
 
         if (!response.Success)
             Console.WriteLine($"Failed to create index: {response.DebugInformation}");

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -25,20 +25,15 @@ public class ElasticsearchFixture : IAsyncLifetime
 
     public async Task CreateIndexAsync(string filename, string indexName)
     {
-        var indexraw = await File.ReadAllTextAsync(Path.Combine(_indexFilesPath, filename));
-        var index = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(indexraw);
+        var indexRaw = await File.ReadAllTextAsync(Path.Combine(_indexFilesPath, filename));
+        var client = new ElasticClient();
 
-        var createIndexResponse = await Client.Indices.CreateAsync(indexName, c => c
-            .InitializeUsing(new IndexState
-            {
-                Settings = new IndexSettings(index["mappings"])
-            })
-        );
+        var response = await client.LowLevel.Indices.CreateAsync<StringResponse>(indexName, indexRaw);
 
-        if (!createIndexResponse.IsValid)
-        {
-            throw new Exception("Index creation failed: " + createIndexResponse.DebugInformation);
-        }
+        if (!response.Success)
+            Console.WriteLine($"Failed to create index: {response.DebugInformation}");
+        else
+            Console.WriteLine("Index created successfully.");
     }
 
     public async Task LoadDataAsync(string filename)

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/fixture_generator/assets.py
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/fixture_generator/assets.py
@@ -4,14 +4,16 @@ from random import choice
 from faker import Faker
 
 
-def generate_assets() -> list[dict]:
+def generate_assets(count: int = 2000) -> list[dict]:
     all_assets = []
     fake = Faker("en_GB")
 
+    addresses_per_street = 10
+
     addresses = []
-    for _ in range(100):
+    for _ in range(count // addresses_per_street):
         street_name = fake.street_name()
-        for i in range(10):
+        for i in range(addresses_per_street):
             flat_number = f"{choice([f'Flat {choice([fake.random_digit(), fake.random_letter().upper()])} ', f'Room {fake.random_digit()} ', 'Gge ', ' '])}{i+1}{choice([fake.random_letter().upper(), ''])}"
             address = f"{flat_number} {street_name}".replace("  ", " ").strip().title()
             addresses.append(address)
@@ -69,6 +71,14 @@ def generate_assets() -> list[dict]:
             "numberOfCots": fake.random_int(min=1, max=3),
             "numberOfShowers": fake.random_int(min=1, max=3),
             "isStepFree": fake.boolean()
+        }
+
+        asset["rootAsset"] = fake.uuid4()
+        asset["isActive"] = True if end_of_tenure_date is None else False
+        asset["parentAssetIds"] = [fake.uuid4() for _ in range(fake.random_int(min=0, max=3))]
+
+        asset["assetManagement"] = {
+            
         }
 
         all_assets.append(asset)

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/fixture_generator/tenures.py
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/fixture_generator/tenures.py
@@ -31,7 +31,7 @@ def generate_tenures(assets: list[dict]) -> list[dict]:
         for i in range(member_count):
             member = {}
             member["id"] = fake.uuid4()
-            member["fullName"] = f"{fake.prefix().replace(".","")} {fake.first_name()} {fake.first_name()} {fake.last_name()}"
+            member["fullName"] = f'{fake.prefix().replace(".","")} {fake.first_name()} {fake.first_name()} {fake.last_name()}'
             member["isResponsible"] = i == 0 # First member is responsible
             member["dateOfBirth"] = fake.date_of_birth().strftime("%Y-%m-%dT%H:%M:%SZ")
             member["personTenureType"] = "Freeholder" if member["isResponsible"] else "HouseholdMember"


### PR DESCRIPTION
It's important for the V2 tests to work based on the indexes defined in `HousingSearchApi/data/elasticsearch`, as these mappings are supposed to reflect the mappings in our deployed environments (they don't but that's a matter for a separate PR)

The V1 tests also create the indexes based on these definitions.

For this PR the V2 tests create indexes with the definitions in that folder to allow future PRs to update the definitions / mappings and have the changes be validated with tests.