### PR TITLE
Speed up V1 tests

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -63,14 +63,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                     .ConfigureAwait(true);
 
                 var assets = CreateAssetData();
-                var awaitable = ElasticSearchClient.IndexManyAsync(assets, INDEX).ConfigureAwait(true);
 
-                while (!awaitable.GetAwaiter().IsCompleted)
-                {
-
-                }
-
-                Thread.Sleep(5000);
+                ElasticSearchClient.IndexMany(assets, INDEX);
+                do
+                    Thread.Sleep(100);
+                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
             }
         }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -58,16 +58,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             if (!ElasticSearchClient.Indices.Exists(Indices.Index(INDEX)).Exists)
             {
-                var assetSettingsDoc = File.ReadAllTextAsync("./data/elasticsearch/assetIndex.json").Result;
-                ElasticSearchClient.LowLevel.Indices.CreateAsync<BytesResponse>(INDEX, assetSettingsDoc)
-                    .ConfigureAwait(true);
+                // clear index
+                ElasticSearchClient.Indices.Delete(Indices.Index(INDEX));
+                var assetSettingsDoc = File.ReadAllText("./data/elasticsearch/assetIndex.json");
+                ElasticSearchClient.LowLevel.Indices.Create<BytesResponse>(INDEX, assetSettingsDoc);
+                ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
 
+                // load data
                 var assets = CreateAssetData();
-
                 ElasticSearchClient.IndexMany(assets, INDEX);
-                do
-                    Thread.Sleep(100);
-                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+                ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
             }
         }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
@@ -29,16 +29,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             if (!ElasticSearchClient.Indices.Exists(Indices.Index(INDEX)).Exists)
             {
-                var personSettingsDoc = File.ReadAllTextAsync("./data/elasticsearch/personIndex.json").Result;
-                ElasticSearchClient.LowLevel.Indices.CreateAsync<BytesResponse>(INDEX, personSettingsDoc)
-                    .ConfigureAwait(true);
+                // clear index
+                ElasticSearchClient.Indices.Delete(Indices.Index(INDEX));
+                var personSettingsDoc = File.ReadAllText("./data/elasticsearch/tenureIndex.json");
+                ElasticSearchClient.LowLevel.Indices.Create<BytesResponse>(INDEX, personSettingsDoc);
+                ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
 
+                // load data
                 var persons = CreatePersonData();
-
                 ElasticSearchClient.IndexMany(persons, INDEX);
-                do
-                    Thread.Sleep(100);
-                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+                ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
             }
         }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
@@ -124,9 +124,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             listOfPersons.Add(specificPerson4);
 
             ElasticSearchClient.IndexMany(listOfPersons, INDEX);
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenDifferentTypesOfTenureTypes(string firstName, string lastName, List<string> list)
@@ -150,9 +148,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             }
 
             ElasticSearchClient.IndexMany(listOfPersons, INDEX);
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenThereExistPersonsWithDifferentPersonTypes(string firstName, string lastName, List<PersonType> personTypes)
@@ -170,9 +166,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             }
 
             ElasticSearchClient.IndexMany(listOfPersons, INDEX);
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
@@ -34,14 +34,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                     .ConfigureAwait(true);
 
                 var persons = CreatePersonData();
-                var awaitable = ElasticSearchClient.IndexManyAsync(persons, INDEX).ConfigureAwait(true);
 
-                while (!awaitable.GetAwaiter().IsCompleted)
-                {
-
-                }
-
-                Thread.Sleep(5000);
+                ElasticSearchClient.IndexMany(persons, INDEX);
+                do
+                    Thread.Sleep(100);
+                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
             }
         }
 
@@ -126,11 +123,10 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             specificPerson3.Surname = lastName + lastName;
             listOfPersons.Add(specificPerson4);
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfPersons, INDEX).ConfigureAwait(true);
-
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(5000);
+            ElasticSearchClient.IndexMany(listOfPersons, INDEX);
+            do
+                Thread.Sleep(100);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenDifferentTypesOfTenureTypes(string firstName, string lastName, List<string> list)
@@ -153,11 +149,10 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 });
             }
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfPersons, INDEX).ConfigureAwait(true);
-
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(5000);
+            ElasticSearchClient.IndexMany(listOfPersons, INDEX);
+            do
+                Thread.Sleep(100);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenThereExistPersonsWithDifferentPersonTypes(string firstName, string lastName, List<PersonType> personTypes)
@@ -174,11 +169,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 });
             }
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfPersons, INDEX).ConfigureAwait(true);
-
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(5000);
+            ElasticSearchClient.IndexMany(listOfPersons, INDEX);
+            do
+            {
+                Thread.Sleep(100);
+            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/PersonsFixture.cs
@@ -171,9 +171,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             ElasticSearchClient.IndexMany(listOfPersons, INDEX);
             do
-            {
                 Thread.Sleep(100);
-            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -54,14 +54,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                                                     .ConfigureAwait(true);
 
                 var processes = Processes.Select(x => x.ToDatabase());
-                var awaitable = ElasticSearchClient.IndexManyAsync(processes, INDEX).ConfigureAwait(true);
 
-                while (!awaitable.GetAwaiter().IsCompleted)
-                {
-
-                }
-
-                Thread.Sleep(5000);
+                ElasticSearchClient.IndexMany(processes, INDEX);
+                do
+                    Thread.Sleep(100);
+                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
             }
         }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -56,9 +56,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 var processes = Processes.Select(x => x.ToDatabase());
 
                 ElasticSearchClient.IndexMany(processes, INDEX);
-                do
-                    Thread.Sleep(100);
-                while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+                ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
             }
         }
 

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -99,9 +99,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
             do
-            {
                 Thread.Sleep(100);
-            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenATenureWithSpecificUprn(string uprn)
@@ -116,9 +115,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
             do
-            {
                 Thread.Sleep(100);
-            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenTaTenuresExist(int tenuresToCreate)
@@ -136,7 +134,9 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             while (!awaitable.GetAwaiter().IsCompleted) { }
 
-            Thread.Sleep(10000);
+            do
+                Thread.Sleep(100);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenSimilarTaTenuresExist(string bookingStatus, string fullName)
@@ -163,9 +163,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
             do
-            {
                 Thread.Sleep(100);
-            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenTenuresWithDifferentStartDatesExist()
@@ -198,9 +197,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
             do
-            {
                 Thread.Sleep(100);
-            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -26,23 +26,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public void GivenATenureIndexExists()
         {
             ElasticSearchClient.Indices.Delete(Indices.Index(INDEX));
+            var tenureSettingsDoc = File.ReadAllText("./data/elasticsearch/tenureIndex.json");
+            ElasticSearchClient.LowLevel.Indices.Create<BytesResponse>(INDEX, tenureSettingsDoc);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
 
-            if (!ElasticSearchClient.Indices.Exists(Indices.Index(INDEX)).Exists)
-            {
-                var tenureSettingsDoc = File.ReadAllTextAsync("./data/elasticsearch/tenureIndex.json").Result;
-                ElasticSearchClient.LowLevel.Indices.CreateAsync<BytesResponse>(INDEX, tenureSettingsDoc)
-                    .ConfigureAwait(true);
-
-                var tenures = CreateTenureData();
-                var awaitable = ElasticSearchClient.IndexManyAsync(tenures, INDEX).ConfigureAwait(true);
-
-                while (!awaitable.GetAwaiter().IsCompleted)
-                {
-
-                }
-
-                Thread.Sleep(1000);
-            }
+            // load data
+            var tenures = CreateTenureData();
+            ElasticSearchClient.IndexMany(tenures, INDEX);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         private List<QueryableTenure> CreateTenureData()

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -96,11 +96,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             thirdTenure.HouseholdMembers.First().FullName = fullName;
             listOfTenures.Add(forthTenure);
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+            ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(10000);
+            do
+            {
+                Thread.Sleep(100);
+            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenATenureWithSpecificUprn(string uprn)
@@ -112,11 +113,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 
             listOfTenures.Add(tenure);
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+            ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(10000);
+            do
+            {
+                Thread.Sleep(100);
+            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenTaTenuresExist(int tenuresToCreate)
@@ -158,11 +160,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             thirdTenure.HouseholdMembers.First().FullName = fullName;
             listOfTenures.Add(thirdTenure);
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+            ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(10000);
+            do
+            {
+                Thread.Sleep(100);
+            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
 
         public void GivenTenuresWithDifferentStartDatesExist()
@@ -192,11 +195,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             oldestTenure.Id = oldestRecord;
             listOfTenures.Add(oldestTenure);
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
+            ElasticSearchClient.IndexMany(listOfTenures, INDEX);
 
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(10000);
+            do
+            {
+                Thread.Sleep(100);
+            } while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TenureFixture.cs
@@ -88,10 +88,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             listOfTenures.Add(forthTenure);
 
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
-
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenATenureWithSpecificUprn(string uprn)
@@ -104,10 +101,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             listOfTenures.Add(tenure);
 
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
-
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenTaTenuresExist(int tenuresToCreate)
@@ -121,13 +115,8 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 listOfTenures.Add(tenure);
             }
 
-            var awaitable = ElasticSearchClient.IndexManyAsync(listOfTenures, INDEX).ConfigureAwait(true);
-
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.IndexMany(listOfTenures, INDEX);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenSimilarTaTenuresExist(string bookingStatus, string fullName)
@@ -152,10 +141,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             listOfTenures.Add(thirdTenure);
 
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
-
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
 
         public void GivenTenuresWithDifferentStartDatesExist()
@@ -186,10 +172,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             listOfTenures.Add(oldestTenure);
 
             ElasticSearchClient.IndexMany(listOfTenures, INDEX);
-
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(INDEX));
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TransactionsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TransactionsFixture.cs
@@ -47,9 +47,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             var transactions = CreateTransactionsData(20);
 
             ElasticSearchClient.IndexMany(transactions, IndexName);
-            do
-                Thread.Sleep(100);
-            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(IndexName)).IsValid);
+            ElasticSearchClient.Indices.Refresh(Indices.Index(IndexName));
         }
 
         private List<QueryableTransaction> CreateTransactionsData(int transactionsCount)

--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TransactionsFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/TransactionsFixture.cs
@@ -45,11 +45,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 .ConfigureAwait(true);
 
             var transactions = CreateTransactionsData(20);
-            var awaitable = ElasticSearchClient.IndexManyAsync(transactions, IndexName).ConfigureAwait(true);
 
-            while (!awaitable.GetAwaiter().IsCompleted) { }
-
-            Thread.Sleep(5000);
+            ElasticSearchClient.IndexMany(transactions, IndexName);
+            do
+                Thread.Sleep(100);
+            while (!ElasticSearchClient.Indices.Refresh(Indices.Index(IndexName)).IsValid);
         }
 
         private List<QueryableTransaction> CreateTransactionsData(int transactionsCount)


### PR DESCRIPTION
V1 tests are disruptive when iterating on a feature because they were taking up to 13 minutes to run.

This PR removes all instances of `Thread.Sleep` from the V1 setup to speed them up down to about 4-5 minutes.

Before:
![image](https://github.com/user-attachments/assets/87b140b9-b730-4246-a721-098062eee9ad)

After:
![image](https://github.com/user-attachments/assets/213cc75e-aa7e-4795-8089-8f4795da1b84)
