### PR TITLE
Better data load for tests v2

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -1,8 +1,6 @@
 using Nest;
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using Elasticsearch.Net;
 using Xunit;
 
 namespace HousingSearchApi.Tests.V2.E2ETests.Fixtures;
@@ -11,9 +9,6 @@ public class ElasticsearchFixture : IAsyncLifetime
 {
     public IElasticClient Client { get; private set; }
 
-    public string FixtureFilesPath = "V2/E2ETests/Fixtures/Files";
-    private string _indexFilesPath = "data/elasticsearch";
-
     public ElasticsearchFixture()
     {
         var url = Environment.GetEnvironmentVariable("ELASTICSEARCH_DOMAIN_URL") ?? "http://localhost:9200";
@@ -21,55 +16,8 @@ public class ElasticsearchFixture : IAsyncLifetime
         Client = new ElasticClient(settings);
     }
 
-    public void CreateIndex(string filename, string indexName)
-    {
-        var existsResponse = Client.Indices.Exists(indexName);
-        if (existsResponse.Exists)
-            Client.Indices.Delete(indexName);
-
-        var indexDefinition = File.ReadAllText(Path.Combine(_indexFilesPath, filename));
-        var response = Client.LowLevel.Indices.Create<StringResponse>(indexName, indexDefinition);
-
-        if (!response.Success)
-            throw new Exception("Failed to create index: " + response.DebugInformation);
-        Console.WriteLine("Index created successfully.");
-    }
-
-    public void LoadData(string filename, string indexName)
-    {
-        Console.WriteLine($"Loading data from {filename} into index {indexName}");
-        string jsonFilePath = Path.Combine(FixtureFilesPath, filename);
-        if (!File.Exists(jsonFilePath))
-            throw new FileNotFoundException($"The file {jsonFilePath} could not be found in directory {Directory.GetCurrentDirectory()}");
-
-        string jsonContent = File.ReadAllText(jsonFilePath);
-
-        // Perform the bulk insert with immediate refresh
-        var bulkResponse = Client.LowLevel.Bulk<StringResponse>(
-            PostData.String(jsonContent),
-            new BulkRequestParameters { Refresh = Refresh.WaitFor }
-        );
-
-        if (!bulkResponse.Success)
-            throw new Exception("Bulk insert failed: " + bulkResponse.DebugInformation);
-    }
-
     public Task InitializeAsync()
     {
-        var indexSettingsFiles = new string[] { "assetIndex.json", "tenureIndex.json", "personIndex.json" };
-
-        foreach (string filename in indexSettingsFiles)
-        {
-            var indexName = filename.Replace("Index.json", "") + "s";
-            CreateIndex(filename, indexName);
-        }
-
-        var filenames = new string[] { "assets.json", "tenures.json", "persons.json" };
-        foreach (string filename in filenames)
-        {
-            var indexName = filename.Replace(".json", "");
-            LoadData(filename, indexName);
-        }
 
         return Task.CompletedTask;
     }

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/load_data.sh
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/load_data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ES_BASE_URL=$ELASTICSEARCH_DOMAIN_URL
+ES_BASE_URL="test-elasticsearch:9200" # < hardcoding for safety
 CWD=$(pwd)
 INDEX_DIR="/setup/indices"
 DATA_DIR="/setup/data"

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/load_data.sh
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/load_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+ES_BASE_URL=$ELASTICSEARCH_DOMAIN_URL
+CWD=$(pwd)
+INDEX_DIR="/setup/indices"
+DATA_DIR="/setup/data"
+
+apk add --no-cache curl
+
+# delete indices if they exist
+curl -X DELETE "$ES_BASE_URL/persons"
+curl -X DELETE "$ES_BASE_URL/tenures"
+curl -X DELETE "$ES_BASE_URL/assets"
+
+
+echo "Creating indices..."
+
+# Create indices
+curl -X PUT "$ES_BASE_URL/persons" -H 'Content-Type: application/json' -d @"$INDEX_DIR/personIndex.json"
+curl -X PUT "$ES_BASE_URL/tenures" -H 'Content-Type: application/json' -d @"$INDEX_DIR/tenureIndex.json"
+curl -X PUT "$ES_BASE_URL/assets" -H 'Content-Type: application/json' -d @"$INDEX_DIR/assetIndex.json"
+
+echo "Indices created."
+
+echo "Inserting data..."
+
+# Insert bulk data
+for index in "persons" "tenures" "assets"; do
+    ES_ENDPOINT="$ES_BASE_URL/$index/_bulk"
+
+    # Loop through each file in the index directory
+    for file in "$DATA_DIR"/*; do
+        if [ -f "$file" ]; then
+            echo "Processing $file for index $index"
+            curl -s -H "Content-Type: application/json" -XPOST "$ES_ENDPOINT" --data-binary "@$file"
+        else
+            echo "No files found in $DATA_DIR"
+        fi
+    done
+done
+
+echo "Bulk insert completed."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
     <<: *housing-search-api-test
     profiles:
       - test-v2
+    depends_on:
+      data-loader:
+        condition: service_completed_successfully
     command: ["dotnet", "test", "--filter", "HousingSearchApi.Tests.V2"]
 
   test-elasticsearch:
@@ -57,6 +60,20 @@ services:
     ports:
       - 9200:9200
       - 9300:9300
+    
+  data-loader:
+    image: alpine
+    container_name: data-loader
+    volumes:
+      - ./HousingSearchApi/data/elasticsearch:/setup/indices
+      - ./HousingSearchApi.Tests/V2/E2ETests/Fixtures/Files:/setup/data
+      - ./HousingSearchApi.Tests/V2/E2ETests/Fixtures/load_data.sh:/setup/load_data.sh
+    environment:
+      - ELASTICSEARCH_DOMAIN_URL=test-elasticsearch:9200
+    depends_on:
+      test-elasticsearch:
+        condition: service_healthy
+    command: ["sh", "/setup/load_data.sh"]
 
   kibana:
     image: docker.elastic.co/kibana/kibana:7.9.3


### PR DESCRIPTION
Use a script to load the data instead of the test setup itself - this is much nicer for running locally mainly, and speeds up the tests a bit.

Otherwise you need to actually run the tests in order to have dummy data when running locally.