### PR TITLE
V2 improvement after dev testing

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -208,7 +208,7 @@ public class AssetSearchTests : BaseSearchTests
         // Arrange
         var asset = RandomItem();
         var expectedReturnedId = asset.GetProperty("id").GetString();
-        var searchText = asset.GetProperty("assetId").GetString();
+        var searchText = expectedReturnedId;
         var request = CreateSearchRequest(searchText);
 
         // Act

--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -199,7 +199,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(randomAsset.GetProperty("id").GetString());
-            
+
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }

--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -175,6 +175,35 @@ public class AssetSearchTests : BaseSearchTests
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
 
+    [Fact]
+    public async Task SearchAddress_Typo()
+    {
+        const int maxAttempts = 10;
+        const int minSuccessCount = 8;
+
+        var successCount = await RunWithScore(maxAttempts, async () =>
+        {
+            // Arrange
+            var randomAsset = RandomItem();
+            var randomAddress = randomAsset.GetProperty("assetAddress").GetProperty("addressLine1").GetString();
+
+            var searchText = CreateTypo(randomAddress);
+            var request = CreateSearchRequest(searchText);
+
+            // Act
+            var response = await HttpClient.SendAsync(request);
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var root = GetResponseRootElement(response);
+            root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
+            var firstResult = root.GetProperty("results").GetProperty("assets")[0];
+            firstResult.GetProperty("id").GetString().Should().Be(randomAsset.GetProperty("id").GetString());
+            
+        });
+        successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
+    }
+
     #endregion
 
     #region Tenure

--- a/HousingSearchApi.Tests/V2/E2ETests/BaseSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/BaseSearchTests.cs
@@ -114,10 +114,10 @@ public class BaseSearchTests
     protected string CreateTypo(string text)
     {
         var chars = text.ToCharArray();
-        var randomChar = Random.Next(0, 36);
+        var randomLetter = (char) ('a' + Random.Next(0, 26));
         var charIndexes = chars.Select((c, i) => (c, i)).Where(t => char.IsLetterOrDigit(t.c)).Select(t => t.i).ToList();
         var randomIndex = Random.Next(0, charIndexes.Count);
-        chars[charIndexes[randomIndex]] = (char) ('a' + randomChar);
+        chars[charIndexes[randomIndex]] = randomLetter;
         return new string(chars);
     }
 }

--- a/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/Fixtures/ElasticsearchFixture.cs
@@ -31,8 +31,8 @@ public class ElasticsearchFixture : IAsyncLifetime
         var response = Client.LowLevel.Indices.Create<StringResponse>(indexName, indexDefinition);
 
         if (!response.Success)
-            throw new Exception("Failed to create index: " + response.DebugInformation);
-        Console.WriteLine("Index created successfully.");
+            throw new Exception($"Failed to create index {indexName}: " + response.DebugInformation);
+        Console.WriteLine($"Index {indexName} created successfully.");
     }
 
     public void LoadData(string filename, string indexName)
@@ -57,7 +57,6 @@ public class ElasticsearchFixture : IAsyncLifetime
     public Task InitializeAsync()
     {
         var indexSettingsFiles = new string[] { "assetIndex.json", "tenureIndex.json", "personIndex.json" };
-
         foreach (string filename in indexSettingsFiles)
         {
             var indexName = filename.Replace("Index.json", "") + "s";

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -20,43 +20,42 @@ public class SearchGateway : ISearchGateway
     {
         var shouldOperations = new List<Func<QueryContainerDescriptor<object>, QueryContainer>>() {
             SearchOperations.MultiMatchBestFields(searchParams.SearchText, boost: 6),
-         };
+        };
 
         // Extend search operations depending on the index
         if (indexName == "assets")
         {
-            Fields keywordFields = new[] { "id", "assetAddress.uprn", "propertyReference" };
+            Fields keywordFields = new[] {
+                "id", "assetAddress.uprn", "propertyReference", // Asset fields
+                "tenure.id", "tenure.paymentReference" // Tenure fields
+            };
             Fields addressFieldNames = new[] { "assetAddress.addressLine1", "assetAddress.addressLine2", "assetAddress.postCode" };
-            Fields tenureFields = new[] { "tenure.id", "tenure.paymentReference" };
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 10),
-                SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 10),
-                SearchOperations.WildcardMatch(searchParams.SearchText, fieldNames: new[] {"assetAddress.addressLine1"}, boost: 10),
-                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: tenureFields, boost: 10),
+                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 15),
+                SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 8),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {"assetAddress.addressLine1"}, boost: 6),
             });
         }
         else if (indexName == "tenures")
         {
-            Fields nameFields = new[] { "householdMembers.fullName" };
+            Field nameField = "householdMembers.fullName";
             Fields keywordFields = new[] { "id", "paymentReference", "tenuredAsset.id", "tenuredAsset.uprn" };
-            Fields addressFieldNames = new[] {
-                "tenuredAsset.fullAddress"
-            };
+            Field addressField = "tenuredAsset.fullAddress";
+
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.WildcardMatch(searchParams.SearchText, fieldNames: nameFields, boost: 10),
-                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 10),
-                SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 10),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: 15),
+                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 12),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {addressField}, boost: 10),
             });
         }
         else if (indexName == "persons")
         {
             Fields nameFields = new[] { "title", "firstname", "surname" };
-            Fields addressFields = new[] {
+            Field tenureAddressField = "tenures.assetFullAddress";
+            Fields tenureKeyFields = new[] {
                 "tenures.id",
-                "tenures.assetFullAddress",
-                "tenures.type",
                 "tenures.uprn",
                 "tenures.propertyReference",
                 "tenures.assetId",
@@ -65,18 +64,23 @@ public class SearchGateway : ISearchGateway
 
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.MultiMatchMostFields(searchParams.SearchText, boost: 10, fields: nameFields),
-                SearchOperations.NestedMultiMatch(searchParams.SearchText, "tenures", addressFields, boost: 10),
+                SearchOperations.MatchFields(searchParams.SearchText, fields: nameFields, boost: 12),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: nameFields, boost: 8),
+                SearchOperations.Nested(
+                    path: "tenures",
+                    func: SearchOperations.MatchField(searchParams.SearchText, field: tenureAddressField, boost: 10)
+                ),
+                SearchOperations.Nested(
+                    path: "tenures",
+                    func: SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] { tenureAddressField }, boost: 8)
+                ),
+                SearchOperations.Nested(
+                    path: "tenures",
+                    func: SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: tenureKeyFields, boost: 12)
+                ),
             });
         }
-        else
-        {
-            shouldOperations.AddRange(
-                new[] {
-                    SearchOperations.MultiMatchBestFields(searchParams.SearchText, boost: 6)
-                }
-            );
-        }
+
         var searchResponse = await _elasticClient.SearchAsync<object>(s => s
             .Index(indexName)
             .Query(q => q

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -26,26 +26,31 @@ public class SearchGateway : ISearchGateway
         if (indexName == "assets")
         {
             Fields keywordFields = new[] {
-                "id", "assetAddress.uprn", "propertyReference", // Asset fields
-                "tenure.id", "tenure.paymentReference" // Tenure fields
+                "id", "assetAddress.uprn", "propertyReference", 
+                "tenure.id", "tenure.paymentReference"
             };
             Fields addressFieldNames = new[] { "assetAddress.addressLine1", "assetAddress.addressLine2", "assetAddress.postCode" };
             shouldOperations.AddRange(new[]
             {
                 SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 15),
                 SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 8),
+                SearchOperations.MatchField(searchParams.SearchText, field: "assetAddress.addressLine1", boost: 12),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {"assetAddress.addressLine1"}, boost: 6),
             });
         }
         else if (indexName == "tenures")
         {
             Field nameField = "householdMembers.fullName";
-            Fields keywordFields = new[] { "id", "paymentReference", "tenuredAsset.id", "tenuredAsset.uprn" };
+            Fields keywordFields = new[] {
+                "id", "paymentReference",
+                "tenuredAsset.id", "tenuredAsset.uprn"
+            };
             Field addressField = "tenuredAsset.fullAddress";
 
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: 15),
+                SearchOperations.MatchField(searchParams.SearchText, field: nameField, boost: 12),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: 10),
                 SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 12),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {addressField}, boost: 10),
             });

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -26,7 +26,7 @@ public class SearchGateway : ISearchGateway
         if (indexName == "assets")
         {
             Fields keywordFields = new[] {
-                "id", "assetAddress.uprn", "propertyReference", 
+                "id", "assetAddress.uprn", "propertyReference",
                 "tenure.id", "tenure.paymentReference"
             };
             Fields addressFieldNames = new[] { "assetAddress.addressLine1", "assetAddress.addressLine2", "assetAddress.postCode" };

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -10,12 +10,12 @@ static class SearchOperations
 {
     public static Func<QueryContainerDescriptor<object>, QueryContainer>
         Nested(string path, Func<QueryContainerDescriptor<object>, QueryContainer> func)
-        {
-            return should => should.Nested(n => n
-                .Path(path)
-                .Query(func)
-            );
-        }
+    {
+        return should => should.Nested(n => n
+            .Path(path)
+            .Query(func)
+        );
+    }
 
     // Score for matching a single (best) field
     public static Func<QueryContainerDescriptor<object>, QueryContainer>

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -26,7 +26,6 @@ static class SearchOperations
                 .Query(searchText)
                 .Type(TextQueryType.BestFields)
                 .Operator(Operator.And)
-                .Fuzziness(Fuzziness.Auto)
                 .Boost(boost)
             );
 

--- a/HousingSearchApi/data/elasticsearch/assetIndex.json
+++ b/HousingSearchApi/data/elasticsearch/assetIndex.json
@@ -248,6 +248,27 @@
       },
       "assetContract": {
         "properties": {
+          "approvalDate": {
+            "type": "date"
+          },
+          "approvalStatus": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "approvalStatusReason": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
           "charges": {
             "properties": {
               "amount": {
@@ -269,6 +290,15 @@
                   }
                 }
               },
+              "subType": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
               "type": {
                 "type": "text",
                 "fields": {
@@ -286,6 +316,73 @@
                 "type": "keyword"
               }
             }
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isApproved": {
+            "type": "boolean"
+          },
+          "relatedPeople": {
+            "properties": {
+              "id": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "name": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "subType": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "type": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          },
+          "startDate": {
+            "type": "date"
+          },
+          "targetId": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "targetType": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           }
         }
       }
@@ -293,7 +390,7 @@
   },
   "settings": {
     "index": {
-      "number_of_shards": "5",
+      "number_of_shards": "1",
       "number_of_replicas": "1"
     }
   }


### PR DESCRIPTION
Improvements to search V2 based on testing in dev - it is inflexible at times and performs inconsistently with names and addresses depending on the index, so this PR unifies the strategy for matching names and addresses

## All
- Boosts adjusted to favour more exact matching and less fuzzy matching to help ensure more relevant results appear first when specifically searched for
- Keyword search is no longer fuzzy / typo tolerant. This roughly doubles the search speed so it's part of a tradeoff. Users also had a minor complaint about irrelevant results when e.g. searching by payment ref. Keywords are the IDs, propref, payment ref, and UPRN
- Strategy for matching free text fields is "MatchField" plus "WildcardMatch" which should give good results with both precise matches with typo tolerance, or partial matches without typo tolerance. This is usually slow but we have so little data (100k records is tiny for Elasticsearch) that performance isn't much of a concern

## Asset search
- Keyword search for assets and tenure combined (should be a bit faster and it simplifies the code)

## Person search
- Nested operation used to simplify the logic of matching the name fields and keyword fields