### PR TITLE
Better-address-search-v2

### DIFF
--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -117,7 +117,7 @@ public class SearchGateway : ISearchGateway
                 .Should(
                     SearchOperations.MatchPhrasePrefix(searchText, field, boost: HighBoost),
                     SearchOperations.MatchField(searchText, field, boost: MediumBoost),
-                    SearchOperations.WildcardMatch(searchText, field, boost: HighBoost)
+                    SearchOperations.QueryStringQuery(searchText, new List<string> { field.ToString() }, boost: HighBoost)
                 )
             );
 

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -117,7 +117,7 @@ public class SearchGateway : ISearchGateway
                 .Should(
                     SearchOperations.MatchPhrasePrefix(searchText, field, boost: HighBoost),
                     SearchOperations.MatchField(searchText, field, boost: MediumBoost),
-                    SearchOperations.WildcardQueryStringQuery(searchText, new[] {field}, boost: HighBoost)
+                    SearchOperations.WildcardQueryStringQuery(searchText, new[] { field }, boost: HighBoost)
                 )
             );
 

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -35,7 +35,8 @@ public class SearchGateway : ISearchGateway
             {
                 SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 15),
                 SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 8),
-                SearchOperations.MatchField(searchParams.SearchText, field: keyAddressField, boost: 8),
+                SearchOperations.MatchField(searchParams.SearchText, field: keyAddressField, boost: 10),
+                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: keyAddressField, boost: 8),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {keyAddressField}, boost: 15),
             });
         }
@@ -54,6 +55,7 @@ public class SearchGateway : ISearchGateway
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: 10),
                 SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 12),
                 SearchOperations.MatchField(searchParams.SearchText, field: addressField, boost: 8),
+                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: addressField, boost: 8),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {addressField}, boost: 10),
             });
         }
@@ -73,6 +75,10 @@ public class SearchGateway : ISearchGateway
             {
                 SearchOperations.MatchFields(searchParams.SearchText, fields: nameFields, boost: 12),
                 SearchOperations.WildcardMatch(searchParams.SearchText, fields: nameFields, boost: 8),
+                SearchOperations.Nested(
+                    path: "tenures",
+                    func: SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: tenureAddressField, boost: 12)
+                ),
                 SearchOperations.Nested(
                     path: "tenures",
                     func: SearchOperations.MatchField(searchParams.SearchText, field: tenureAddressField, boost: 10)
@@ -110,4 +116,18 @@ public class SearchGateway : ISearchGateway
             Total = searchResponse.HitsMetadata.Total.Value,
         };
     }
+
+
+    // private static Func<QueryContainerDescriptor<object>, QueryContainer>
+    //     MatchAddressField(string searchText, Field field, int boost) =>
+    //     should => should
+    //         .Bool(b => b
+    //             .Should(
+    //                 SearchOperations.MatchField(searchText, field, boost),
+    //                 SearchOperations.MatchPhrasePrefix(searchText, field, boost),
+    //                 SearchOperations.WildcardMatch(searchText, field, boost)
+    //             )
+    //         );
+
+
 }

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -117,7 +117,7 @@ public class SearchGateway : ISearchGateway
                 .Should(
                     SearchOperations.MatchPhrasePrefix(searchText, field, boost: HighBoost),
                     SearchOperations.MatchField(searchText, field, boost: MediumBoost),
-                    SearchOperations.QueryStringQuery(searchText, new List<string> { field.ToString() }, boost: HighBoost)
+                    SearchOperations.WildcardQueryStringQuery(searchText, new[] {field}, boost: HighBoost)
                 )
             );
 

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -11,6 +11,10 @@ public class SearchGateway : ISearchGateway
 {
     private readonly IElasticClient _elasticClient;
 
+    const int HighBoost = 3;
+    const int MediumBoost = 2;
+    const int LowBoost = 1;
+
     public SearchGateway(IElasticClient elasticClient)
     {
         _elasticClient = elasticClient;
@@ -18,6 +22,7 @@ public class SearchGateway : ISearchGateway
 
     public async Task<SearchResponseDto> Search(string indexName, SearchParametersDto searchParams)
     {
+
         var shouldOperations = new List<Func<QueryContainerDescriptor<object>, QueryContainer>>() {
             SearchOperations.MultiMatchBestFields(searchParams.SearchText, boost: 6),
         };
@@ -33,11 +38,9 @@ public class SearchGateway : ISearchGateway
             Fields addressFieldNames = new[] { "assetAddress.addressLine1", "assetAddress.addressLine2", "assetAddress.postCode" };
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 15),
-                SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: 8),
-                SearchOperations.MatchField(searchParams.SearchText, field: keyAddressField, boost: 10),
-                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: keyAddressField, boost: 8),
-                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {keyAddressField}, boost: 15),
+                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: HighBoost),
+                SearchOperations.MultiMatchCrossFields(searchParams.SearchText, fields: addressFieldNames, boost: LowBoost),
+                MatchAddressField(searchParams.SearchText, keyAddressField),
             });
         }
         else if (indexName == "tenures")
@@ -51,12 +54,10 @@ public class SearchGateway : ISearchGateway
 
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.MatchField(searchParams.SearchText, field: nameField, boost: 12),
-                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: 10),
-                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: 12),
-                SearchOperations.MatchField(searchParams.SearchText, field: addressField, boost: 8),
-                SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: addressField, boost: 8),
-                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] {addressField}, boost: 10),
+                SearchOperations.MatchField(searchParams.SearchText, field: nameField, boost: MediumBoost),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: new [] {nameField}, boost: LowBoost),
+                SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: keywordFields, boost: MediumBoost),
+                MatchAddressField(searchParams.SearchText, addressField),
             });
         }
         else if (indexName == "persons")
@@ -73,23 +74,15 @@ public class SearchGateway : ISearchGateway
 
             shouldOperations.AddRange(new[]
             {
-                SearchOperations.MatchFields(searchParams.SearchText, fields: nameFields, boost: 12),
-                SearchOperations.WildcardMatch(searchParams.SearchText, fields: nameFields, boost: 8),
+                SearchOperations.MatchFields(searchParams.SearchText, fields: nameFields, boost: HighBoost),
+                SearchOperations.WildcardMatch(searchParams.SearchText, fields: nameFields, boost: LowBoost),
                 SearchOperations.Nested(
                     path: "tenures",
-                    func: SearchOperations.MatchPhrasePrefix(searchParams.SearchText, field: tenureAddressField, boost: 12)
+                    func: SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: tenureKeyFields, boost: HighBoost)
                 ),
                 SearchOperations.Nested(
                     path: "tenures",
-                    func: SearchOperations.MatchField(searchParams.SearchText, field: tenureAddressField, boost: 10)
-                ),
-                SearchOperations.Nested(
-                    path: "tenures",
-                    func: SearchOperations.WildcardMatch(searchParams.SearchText, fields: new[] { tenureAddressField }, boost: 8)
-                ),
-                SearchOperations.Nested(
-                    path: "tenures",
-                    func: SearchOperations.MultiMatchBestFields(searchParams.SearchText, fields: tenureKeyFields, boost: 12)
+                    func: MatchAddressField(searchParams.SearchText, tenureAddressField)
                 ),
             });
         }
@@ -117,17 +110,16 @@ public class SearchGateway : ISearchGateway
         };
     }
 
-
-    // private static Func<QueryContainerDescriptor<object>, QueryContainer>
-    //     MatchAddressField(string searchText, Field field, int boost) =>
-    //     should => should
-    //         .Bool(b => b
-    //             .Should(
-    //                 SearchOperations.MatchField(searchText, field, boost),
-    //                 SearchOperations.MatchPhrasePrefix(searchText, field, boost),
-    //                 SearchOperations.WildcardMatch(searchText, field, boost)
-    //             )
-    //         );
+    private Func<QueryContainerDescriptor<object>, QueryContainer>
+        MatchAddressField(string searchText, Field field) =>
+        should => should
+            .Bool(b => b
+                .Should(
+                    SearchOperations.MatchPhrasePrefix(searchText, field, boost: HighBoost),
+                    SearchOperations.MatchField(searchText, field, boost: MediumBoost),
+                    SearchOperations.WildcardMatch(searchText, field, boost: HighBoost)
+                )
+            );
 
 
 }

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -126,16 +126,17 @@ static class SearchOperations
                 .Boost(boost)
                 .Slop(1)
             );
-    
+
     public static Func<QueryContainerDescriptor<object>, QueryContainer>
-        MatchPhrasePrefixFields(string searchText, Fields fields, int boost) {
-            return should => should.Bool(b => b
-                .Should(
-                    fields.Select(fieldName =>
-                        MatchPhrasePrefix(searchText, fieldName, boost)
-                    ).ToArray()
-                )
-            );
-        }
-        
+        MatchPhrasePrefixFields(string searchText, Fields fields, int boost)
+    {
+        return should => should.Bool(b => b
+            .Should(
+                fields.Select(fieldName =>
+                    MatchPhrasePrefix(searchText, fieldName, boost)
+                ).ToArray()
+            )
+        );
+    }
+
 }

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -140,38 +140,15 @@ static class SearchOperations
     }
 
 
-    public static Func<QueryContainerDescriptor<object>, QueryContainer> QueryStringQuery(string searchText,
-            List<string> fields, double? boost = null)
+    public static Func<QueryContainerDescriptor<object>, QueryContainer> WildcardQueryStringQuery(string searchText,
+            Fields fields, double? boost = null)
     {
-        List<string> ProcessWildcards(string phrase)
-        {
-            if (string.IsNullOrEmpty(phrase))
-                return new List<string>();
-            return phrase.Split(' ').Select(word => $"*{word}*").ToList();
-        }
-
-        var listOfWildCardedWords = ProcessWildcards(searchText);
-        var queryString = $"({string.Join(" AND ", listOfWildCardedWords)}) " +
-                          string.Join(' ', listOfWildCardedWords);
-
-        Func<QueryContainerDescriptor<object>, QueryContainer> query =
-            should => should.QueryString(q =>
-            {
-                var queryDescriptor = q.Query(queryString)
-                    .Fields(f =>
-                    {
-                        foreach (var field in fields)
-                        {
-                            f = f.Field(field, boost);
-                        }
-
-                        return f;
-                    });
-
-                return queryDescriptor;
-            });
-
-        return query;
+        var queryString = string.Join(" AND ", searchText.Split(' ').Select(word => $"*{word}*"));
+        return should => should.QueryString(q => q
+            .Query(queryString)
+            .Fields(fields)
+            .Boost(boost)
+        );
     }
 
 }

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -116,4 +116,26 @@ static class SearchOperations
             )
         );
     }
+
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MatchPhrasePrefix(string searchText, Field field, int boost) =>
+        should => should
+            .MatchPhrasePrefix(mp => mp
+                .Field(field)
+                .Query(searchText)
+                .Boost(boost)
+                .Slop(1)
+            );
+    
+    public static Func<QueryContainerDescriptor<object>, QueryContainer>
+        MatchPhrasePrefixFields(string searchText, Fields fields, int boost) {
+            return should => should.Bool(b => b
+                .Should(
+                    fields.Select(fieldName =>
+                        MatchPhrasePrefix(searchText, fieldName, boost)
+                    ).ToArray()
+                )
+            );
+        }
+        
 }


### PR DESCRIPTION
Key issue was that address partial match was limited to prefixes, whereas in v1 there's support for some partial match on each field, e.g. "43 mond" matching "43b richmond road". 

This copies a simplified version of the V1 address search into `WildcardQueryStringQuery` which works for this purpose