### PR TITLE
Search V2 tidy

### DIFF
--- a/HousingSearchApi.Tests/V1/Infrastructure/ElasticSearchExtensionsTests.cs
+++ b/HousingSearchApi.Tests/V1/Infrastructure/ElasticSearchExtensionsTests.cs
@@ -29,6 +29,8 @@ namespace HousingSearchApi.Tests.V1.Infrastructure
             section.Setup(x => x.Value).Returns(url);
             mockConfig.Setup(x => x.GetSection(ConfigKey))
                               .Returns(section.Object);
+            mockConfig.Setup(x => x.GetSection("USING_REMOTE_DB"))
+                              .Returns(new Mock<IConfigurationSection>().Object);
         }
 
         [Fact]

--- a/HousingSearchApi/Properties/launchSettings.json
+++ b/HousingSearchApi/Properties/launchSettings.json
@@ -21,7 +21,8 @@
       "commandName": "Project",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "LocalDevelopment",
-        "ELASTICSEARCH_DOMAIN_URL": "https://localhost:9200"
+        "ELASTICSEARCH_DOMAIN_URL": "https://localhost:9200",
+        "USING_REMOTE_DB": "true"
       },
       "applicationUrl": "http://localhost:3000"
     }

--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -24,17 +24,17 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
                 .PrettyJson()
                 .ThrowExceptions()
                 .DisableDirectStreaming();
-
-            // see corresponding launch profile in launchSettings.json
-            if (configuration.GetValue<string>("USING_REMOTE_DB") == "true")
+            
+            // See dev_database launch profile in launchSettings.json
+            if (configuration.GetValue("USING_REMOTE_DB", "false") == "true")
             {
-                if (url != "https://localhost:9200")
-                    throw new Exception("Remote DB flag is true but the URL is not set to localhost with https - probable misconfiguration");
-
+                // Helps to prevent accidental connections to remote DBs
+                if (!url.StartsWith("https"))
+                    throw new ArgumentException("Remote DB connection must use HTTPS");
                 connectionSettings = connectionSettings
-                    .ServerCertificateValidationCallback(
-                        (sender, certificate, chain, sslPolicyErrors) => true);
+                    .ServerCertificateValidationCallback((sender, certificate, chain, sslPolicyErrors) => true);
             }
+
             var esClient = new ElasticClient(connectionSettings);
 
             services.TryAddSingleton<IElasticClient>(esClient);

--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -24,7 +24,7 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
                 .PrettyJson()
                 .ThrowExceptions()
                 .DisableDirectStreaming();
-            
+
             // See dev_database launch profile in launchSettings.json
             if (configuration.GetValue("USING_REMOTE_DB", "false") == "true")
             {

--- a/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
+++ b/HousingSearchApi/V1/Infrastructure/Extensions/ElasticSearchExtensions.cs
@@ -26,7 +26,8 @@ namespace HousingSearchApi.V1.Infrastructure.Extensions
                 .DisableDirectStreaming();
 
             // see corresponding launch profile in launchSettings.json
-            if (configuration.GetValue<string>("USING_REMOTE_DB") == "true") {
+            if (configuration.GetValue<string>("USING_REMOTE_DB") == "true")
+            {
                 if (url != "https://localhost:9200")
                     throw new Exception("Remote DB flag is true but the URL is not set to localhost with https - probable misconfiguration");
 


### PR DESCRIPTION
Tidy up search V2's gateway by pulling the name search into a function.

Add launch profile for convenience when running the search API against dev - prevents having uncommitted changes and should increase safety by requiring explicit launch profile selection.

Also add 5 for a MinScore which is quite low to be safe. Don't want this high because it might cut out correct search results at some point, but 5 is low so it should be safe while not matching tens of thousands of records