### PR TITLE
Fix default best fields boost level

### DIFF
--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -29,7 +29,7 @@ public class SearchGateway : ISearchGateway
     {
 
         var shouldOperations = new List<Func<QueryContainerDescriptor<object>, QueryContainer>>() {
-            Ops.MultiMatchBestFields(searchParams.SearchText, boost: 6),
+            Ops.MultiMatchBestFields(searchParams.SearchText, boost: BoostLevel.High),
         };
 
         // Extend search operations depending on the index


### PR DESCRIPTION
Was set to 6. Should have been BoostLevel.High (i.e. 3).

I'm worried that it might throw off results in some niche cases being so high