### PR TITLE
TS-1921 Add support for searching by temporaryAccommodationParentAssetId

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using AutoFixture;
 using Elasticsearch.Net;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Persons;
 using Nest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
 
 namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
 {
@@ -16,6 +16,9 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
     {
         public List<QueryablePerson> Persons { get; private set; }
         private const string INDEX = "assets";
+
+        private static readonly Guid _temporaryAccommodationParentAssetId = new("CB1876BB-14EE-4688-9EC3-21869FF176C5");
+
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
@@ -38,7 +41,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             new AddressStub{ FirstLine = "5 Buckland Court St Johns Estate", AssetType = "FirstAsset", PostCode = "N1 6TY", UPRN = "10008235183", ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
             new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
             new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
-            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"}
+            new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
+
+            new AddressStub{ FirstLine = "TA child address one", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10001234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
+            new AddressStub{ FirstLine = "TA child address two", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10002234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
+            new AddressStub{ FirstLine = "TA child address three", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10003234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
         };
 
         private static string GetGuids()
@@ -100,6 +107,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 asset.AssetContracts[0].IsActive = value.ContractIsActive;
                 asset.AssetContracts[0].Charges = asset.AssetContracts[0].Charges.Append(chargeWithSetSubtype);
                 asset.AssetManagement.IsTemporaryAccomodation = value.TemporaryAccommodation;
+                asset.AssetManagement.TemporaryAccommodationParentAssetId = value.TemporaryAccommodationParentAssetId;
                 listOfAssets.Add(asset);
             }
 
@@ -128,6 +136,6 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public string ContractEndReason { get; set; }
         public string ChargesSubType { get; set; }
         public bool TemporaryAccommodation { get; set; }
-
+        public Guid TemporaryAccommodationParentAssetId { get; set; }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -164,6 +164,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
         }
+
+        public async Task WhenTemporaryAccommodationParentAssetIdIsPassed(string taParentAssetId)
+        {
+            var route = new Uri($"api/v1/search/assets/all?temporaryAccommodationParentAssetId={taParentAssetId}&page={1}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
+
         public async Task ThenOnlyTemporaryAccomodationResultsShouldBeIncluded()
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -312,6 +321,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
+        }
+
+        public async Task ThenAllResultsWithPassedTemporaryAccommodationParentAssetIdShouldBeReturned(int expectedNumberOfAssets, Guid parentAssetId)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+            result.Results.Assets.Count.Should().Be(expectedNumberOfAssets);
+            result.Results.Assets.All(x => x.AssetManagement.TemporaryAccommodationParentAssetId == parentAssetId);
+
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -1,5 +1,6 @@
 using HousingSearchApi.Tests.V1.E2ETests.Fixtures;
 using HousingSearchApi.Tests.V1.E2ETests.Steps;
+using System;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -202,7 +203,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsNotActive = "false";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsNotActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 2))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 5))
                 .BDDfy();
         }
         [Fact]
@@ -245,6 +246,17 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenIsTemporaryAccomodationIsTrueAndSearchText("19 buckland"))
                 .Then(t => _steps.ThenThatTemporaryAccomodationAddressShouldBeTheFirstResult("19 Buckland Court St Johns Estate"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ServiceFiltersTemporaryAccommodationParentAssetIdWithoutSearchText()
+        {
+            var temporaryAccommodationParentAssetId = "CB1876BB-14EE-4688-9EC3-21869FF176C5";
+
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenTemporaryAccommodationParentAssetIdIsPassed(temporaryAccommodationParentAssetId))
+                .Then(t => _steps.ThenAllResultsWithPassedTemporaryAccommodationParentAssetIdShouldBeReturned(3, new Guid(temporaryAccommodationParentAssetId)))
                 .BDDfy();
         }
     }

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.82.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.83.0-feat-ts-1698-add0002" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />

--- a/HousingSearchApi/HousingSearchApi.csproj
+++ b/HousingSearchApi/HousingSearchApi.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.83.0-feat-ts-1698-add0002" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.84.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />

--- a/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
+++ b/HousingSearchApi/V1/Boundary/Requests/GetAllAssetListRequest.cs
@@ -50,5 +50,8 @@ namespace HousingSearchApi.V1.Boundary.Requests
 
         [FromQuery(Name = "tenureType")]
         public string TenureType { get; set; }
+
+        [FromQuery(Name = "temporaryAccommodationParentAssetId")]
+        public string TemporaryAccommodationParentAssetId { get; set; }
     }
 }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
 using Hackney.Core.ElasticSearch.Interfaces;
-using HousingSearchApi.V1.Interfaces;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using HousingSearchApi.V1.Boundary.Requests;
+using HousingSearchApi.V1.Interfaces;
 using HousingSearchApi.V1.Interfaces.Factories;
 using Nest;
+using System;
+using System.Collections.Generic;
 
 namespace HousingSearchApi.V1.Infrastructure.Factories
 {
@@ -156,6 +156,7 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })
                         .WithFilterQuery(assetListAllRequest.AssetStatus, new List<string> { "assetManagement.propertyOccupiedStatus" })
                         .WithFilterQuery(assetListAllRequest.TenureType, new List<string> { "tenure.type.keyword" })
+                        .WithFilterQuery(assetListAllRequest.TemporaryAccommodationParentAssetId, new List<string> { "assetManagement.temporaryAccommodationParentAssetId" })
                         .Build(q);
                 }
             }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1921](https://hackney.atlassian.net/browse/TS-1921)

## Describe this PR

### *What is the problem we're trying to solve*

We have added a support for TA blocks to the asset API and search listener, so we need to update this search API too in order to be able to search by `temporaryAccommodationParentAssetId`. This will enable us to provide results that show which units belong to a parent property. Additional flags in the return object will enable TA to further determine whether a unit belongs to a block as well as to the parent property.

### *What changes have we introduced*

1. Update the `Hackney.Shared.HousingSearch` package to the version 0.84.0 which adds support for TA blocks
2. Add new `TemporaryAccommodationParentAssetId` property to `GetAllAssetListRequest` object. This parameter must support queries that don't provide any search text, so it's been implemented in all assets request only
3. Unrelated `ServiceFiltersFalseContractIsActiveStatusWithoutSearchText` story has been updated to use the correct value for matching fixtures. I didn't think contract related properties were relevant for this feature, so I left them out from the fixture. As a result three new objects in the fixture caused that test assertion to fail, so it has been updated to match the new fixture.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1921]: https://hackney.atlassian.net/browse/TS-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ