### PR TITLE
TS-improve ta search text handling

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -42,10 +42,12 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             new AddressStub{ FirstLine = "Gge 15 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,  ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
             new AddressStub{ FirstLine = "Gge 53 Buckland Court St Johns Estate", AssetType = "ThirdAsset", PostCode = "N1 5EP", UPRN = "10008234650", ParentAssetIds = GetGuids(), ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
             new AddressStub{ FirstLine = "Gge 25 Buckland Court St Johns Estate", AssetType = "SecondAsset", PostCode = "N1 5EP", UPRN = "10008234650", ContractIsApproved = true, ContractIsActive = true,   ContractApprovalStatus = "PendingReapproval", ContractApprovalStatusReason = "ContractExtended"},
-
             new AddressStub{ FirstLine = "TA child address one", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10001234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
             new AddressStub{ FirstLine = "TA child address two", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10002234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
             new AddressStub{ FirstLine = "TA child address three", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10003234567", TemporaryAccommodationParentAssetId = _temporaryAccommodationParentAssetId},
+            new AddressStub{ FirstLine = "282", PostCode = "A1", UPRN = "10008234651", TemporaryAccommodation = true},
+            new AddressStub{ FirstLine = "282 high", PostCode = "A1 2B", TemporaryAccommodation = true},
+            new AddressStub{ FirstLine = "282 high street", PostCode = "A1 2BC", TemporaryAccommodation = true},
         };
 
         private static string GetGuids()

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -31,7 +31,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
 
         public async Task WhenAPageSizeIsProvided(int pageSize)
         {
-            var route = new Uri($"api/v1/search/assets?searchText={AssetFixture.Addresses.Last().FirstLine}&pageSize={pageSize}",
+            var route = new Uri($"api/v1/search/assets?searchText=59 Buckland Court St Johns Estate&pageSize={pageSize}",
                 UriKind.Relative);
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
@@ -168,6 +168,13 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
         public async Task WhenTemporaryAccommodationParentAssetIdIsPassed(string taParentAssetId)
         {
             var route = new Uri($"api/v1/search/assets/all?temporaryAccommodationParentAssetId={taParentAssetId}&page={1}",
+                UriKind.Relative);
+
+            _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
+        }
+        public async Task WhenLineOneOrPostcodeOrUPRNisUsedInSearchText(string searchText)
+        {
+            var route = new Uri($"api/v1/search/assets/all?isDesc=false&isFilteredQuery=true&isTemporaryAccomodation=true&page=1&pageSize=7&searchText={searchText}&sortBy=id",
                 UriKind.Relative);
 
             _lastResponse = await _httpClient.GetAsync(route).ConfigureAwait(false);
@@ -330,6 +337,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count.Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetManagement.TemporaryAccommodationParentAssetId == parentAssetId);
 
+        }
+
+        public async Task ThenAllAssetsWithTheGivenLineOneOrPostcodeOrUPRNSearchTextShouldBeReturned(int expectedNumberOfResults)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Count.Should().Be(expectedNumberOfResults);
         }
     }
 }

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -203,7 +203,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsNotActive = "false";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsNotActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 5))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 8))
                 .BDDfy();
         }
         [Fact]
@@ -257,6 +257,27 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenTemporaryAccommodationParentAssetIdIsPassed(temporaryAccommodationParentAssetId))
                 .Then(t => _steps.ThenAllResultsWithPassedTemporaryAccommodationParentAssetIdShouldBeReturned(3, new Guid(temporaryAccommodationParentAssetId)))
+                .BDDfy();
+        }
+
+        [Theory]
+        //Line1
+        [InlineData("282", 3)]
+        [InlineData("282 high", 2)]
+        [InlineData("282 high street", 1)]
+        [InlineData("28 hig treet", 1)]
+        //postcode
+        [InlineData("A1", 3)]
+        [InlineData("A1 2B", 2)]
+        [InlineData("A1 2BC", 1)]
+        //UPRN
+        [InlineData("10008234651", 1)]
+
+        public void ServiceReturnsMatchingTemporaryAccommodationResultsWhenAddressOrPostcodeOrUPRNIsUsed(string searchText, int expectedResults)
+        {
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenLineOneOrPostcodeOrUPRNisUsedInSearchText(searchText))
+                .Then(t => _steps.ThenAllAssetsWithTheGivenLineOneOrPostcodeOrUPRNSearchTextShouldBeReturned(expectedResults))
                 .BDDfy();
         }
     }

--- a/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
+++ b/HousingSearchApi/V1/Infrastructure/Factories/AssetQueryGenerator.cs
@@ -82,13 +82,6 @@ namespace HousingSearchApi.V1.Infrastructure.Factories
                         .WithMultipleFilterQuery(assetListAllRequest.IsActive, new List<string> { "isActive" })
                         .WithWildstarBoolQuery(assetListAllRequest.SearchText,
                             new List<string> { "assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn" })
-                        .WithExactQuery(assetListAllRequest.SearchText,
-                            new List<string>
-                            {
-                            "assetAddress.addressLine1",
-                            "assetAddress.uprn",
-                            "assetAddress.postCode"
-                            })
                         .WithFilterQuery(assetListAllRequest.AssetTypes, new List<string> { "assetType" })
                         .WithFilterQuery(assetListAllRequest.AssetStatus, new List<string> { "assetManagement.propertyOccupiedStatus" })
                         .WithFilterQuery(assetListAllRequest.TenureType, new List<string> { "tenure.type.keyword" })


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1956](https://hackney.atlassian.net/browse/TS-1956)

## Describe this PR

### *What is the problem we're trying to solve*

When searching for TA assets using `282 high road` as a search text for example we get too many results. We get everything that has any of those three words in the line one. What we want is the more words you type the less results you get.

### *What changes have we introduced*
New `WithWildstarBoolQuery` method was introduced in the earlier PR which improves the word matching by reducing results when more words are used. However because the `WithExactQuery` was still enabled it included results outside of what the `WithWildstarBoolQuery` would have returned. This update ensures the search results are filtered down as you type more words.

The search is run against first Line, post code and uprn fields. Tests have been added to check that the behaviour is correct. Because the `WithWildstarBoolQuery` uses wild card search for the words minor typos etc. won't affect the results too much. 

Couple of existing tests have been updated to reflect the new fixture setup and also made them a bit more robust by not relying on position of the records in the fixture.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.


[TS-1956]: https://hackney.atlassian.net/browse/TS-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ