### PR TITLE
BTA/V1: only return AssetContracts with specific status/es

### DIFF
--- a/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Fixtures/AssetFixture.cs
@@ -22,7 +22,11 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public static AddressStub[] Addresses =
         {
             new AddressStub{ FirstLine = "59 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234650",
-                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = false, ContractApprovalStatus = "PendingReapproval", ContractEndReason="ContractHasEnded", ChargesSubType="rate"},
+                AssetStatus = "Reserved", NoOfBedSpaces = 2, NoOfCots = 1, HasStairs = true, PrivateBathroom = true, PrivateKitchen = true, StepFree = true, ParentAssetIds = GetGuids(), ContractIsActive = false, ContractApprovalStatus = "PendingReapproval", SecondContractApprovalStatus = "PendingApproval",
+                        ThirdContractApprovalStatus = "Approved",
+                        FourthContractApprovalStatus = "PendingReapproval",
+                        FifthContractApprovalStatus = "PendingApproval",
+                        ContractEndReason="ContractHasEnded", ChargesSubType="rate"},
             new AddressStub{ FirstLine = "19 Buckland Court St Johns Estate", AssetType = "Dwelling", PostCode = "N1 5EP", UPRN = "10008234699",
                 AssetStatus = "Reserved", NoOfBedSpaces = 1, NoOfCots = 1, HasStairs = true, PrivateBathroom = false, PrivateKitchen = true, StepFree = false, TemporaryAccommodation = true, ParentAssetIds = GetGuids(), ContractIsActive = true, ContractApprovalStatus = "PendingApproval", ContractIsApproved = false },
             new AddressStub{ FirstLine = "38 Buckland Court St Johns Estate", AssetType = "Block", PostCode = "N1 5EP", UPRN = "10008234611",
@@ -84,12 +88,16 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
             {
 
                 var assetContracts = fixture.Build<QueryableAssetContract>()
-                                    .CreateMany(1).ToList();
+                                    .CreateMany(4).ToList();
                 var asset = fixture.Build<QueryableAsset>()
                             .With(f => f.AssetContracts, assetContracts)
                             .Create();
                 var chargeWithSetSubtype = fixture.Create<QueryableCharges>();
                 var parsedApprovalStatus = value.ContractApprovalStatus;
+                var parsedSecondApprovalStatus = value.SecondContractApprovalStatus;
+                var parsedThirdApprovalStatus = value.ThirdContractApprovalStatus;
+                var parsedFourthApprovalStatus = value.FourthContractApprovalStatus;
+                var parsedFifthApprovalStatus = value.FifthContractApprovalStatus;
                 chargeWithSetSubtype.SubType = value.ChargesSubType;
                 asset.AssetAddress.AddressLine1 = value.FirstLine;
                 asset.AssetType = value.AssetType;
@@ -105,6 +113,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
                 asset.ParentAssetIds = value.ParentAssetIds;
                 asset.AssetContracts[0].EndReason = value.ContractEndReason;
                 asset.AssetContracts[0].ApprovalStatus = parsedApprovalStatus;
+                asset.AssetContracts[1].ApprovalStatus = parsedSecondApprovalStatus;
                 asset.AssetContracts[0].ApprovalStatusReason = value.ContractApprovalStatusReason;
                 asset.AssetContracts[0].IsActive = value.ContractIsActive;
                 asset.AssetContracts[0].Charges = asset.AssetContracts[0].Charges.Append(chargeWithSetSubtype);
@@ -133,6 +142,10 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Fixtures
         public string ParentAssetIds { get; set; }
         public bool ContractIsApproved { get; set; }
         public string ContractApprovalStatus { get; set; }
+        public string SecondContractApprovalStatus { get; set; }
+        public string ThirdContractApprovalStatus { get; set; }
+        public string FourthContractApprovalStatus { get; set; }
+        public string FifthContractApprovalStatus { get; set; }
         public string ContractApprovalStatusReason { get; set; }
         public bool ContractIsActive { get; set; }
         public string ContractEndReason { get; set; }

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -290,6 +290,14 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContracts.ElementAt(0).ApprovalStatus.ToString() == contractApprovalStatus);
         }
+        public async Task ThenOnlyContractsWithThatStatusAreReturned(string contractApprovalStatus, int expectedNumberOfAssets)
+        {
+            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
+
+            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
+            result.Results.Assets.All(x => x.AssetContracts != null && x.AssetContracts.All(ac => ac.ApprovalStatus.ToString() == contractApprovalStatus));
+        }
         public async Task ThenAssetsWithProvidedContractApprovalStatusReasonShouldBeIncluded(string contractApprovalStatusReason, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Steps/GetAssetSteps.cs
@@ -290,14 +290,6 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Steps
             result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
             result.Results.Assets.All(x => x.AssetContracts.ElementAt(0).ApprovalStatus.ToString() == contractApprovalStatus);
         }
-        public async Task ThenOnlyContractsWithThatStatusAreReturned(string contractApprovalStatus, int expectedNumberOfAssets)
-        {
-            var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var result = JsonSerializer.Deserialize<APIAllResponse<GetAllAssetListResponse>>(resultBody, _jsonOptions);
-
-            result.Results.Assets.Count().Should().Be(expectedNumberOfAssets);
-            result.Results.Assets.All(x => x.AssetContracts != null && x.AssetContracts.All(ac => ac.ApprovalStatus.ToString() == contractApprovalStatus));
-        }
         public async Task ThenAssetsWithProvidedContractApprovalStatusReasonShouldBeIncluded(string contractApprovalStatusReason, int expectedNumberOfAssets)
         {
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -161,6 +161,15 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
         [Fact]
+        public void ServiceFiltersTwoContractStatusesWithoutSearchText()
+        {
+            var multipleApprovalStatuses = "PendingApproval PendingReapproval";
+            this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
+                .When(w => _steps.WhenContractApprovalStatusIsProvided(multipleApprovalStatuses))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(multipleApprovalStatuses, 11))
+                .BDDfy();
+        }
+        [Fact]
         public void ServiceFiltersSuspensionLiftedReapprovalStatusWithoutSearchText()
         {
             var approvalStatusReason = "SuspensionLifted";

--- a/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
+++ b/HousingSearchApi.Tests/V1/E2ETests/Stories/GetAssetStories.cs
@@ -139,7 +139,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var pendingApprovalStatus = "PendingApproval";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(pendingApprovalStatus))
-                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 2))
+                .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(pendingApprovalStatus, 3))
                 .BDDfy();
         }
         [Fact]
@@ -163,7 +163,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
         [Fact]
         public void ServiceFiltersTwoContractStatusesWithoutSearchText()
         {
-            var multipleApprovalStatuses = "PendingApproval PendingReapproval";
+            var multipleApprovalStatuses = "PendingReapproval%20PendingApproval";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractApprovalStatusIsProvided(multipleApprovalStatuses))
                 .Then(t => _steps.ThenAssetsWithProvidedContractApprovalStatusShouldBeIncluded(multipleApprovalStatuses, 11))
@@ -194,7 +194,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsActive = "true";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsActive, 11))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsActive, 12))
                 .BDDfy();
         }
         [Fact]
@@ -212,7 +212,7 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
             var contractIsNotActive = "false";
             this.Given(g => _assetsFixture.GivenAnAssetIndexExists())
                 .When(w => _steps.WhenContractIsActiveIsProvided(contractIsNotActive))
-                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 8))
+                .Then(t => _steps.ThenAssetsWithProvidedContractStatusShouldBeIncluded(contractIsNotActive, 12))
                 .BDDfy();
         }
         [Fact]
@@ -268,7 +268,6 @@ namespace HousingSearchApi.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenAllResultsWithPassedTemporaryAccommodationParentAssetIdShouldBeReturned(3, new Guid(temporaryAccommodationParentAssetId)))
                 .BDDfy();
         }
-
         [Theory]
         //Line1
         [InlineData("282", 3)]

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -112,10 +112,16 @@ namespace HousingSearchApi.V1.Gateways
                 var filteredQueryableAsset = queryableAsset.CreateAll();
                 if (query.ContractApprovalStatus != null)
                 {
-                    // filtering contracts to only include those with specified status
-                    filteredQueryableAsset.AssetContracts = filteredQueryableAsset.AssetContracts
-                        .Where(c => c.ApprovalStatus == query.ContractApprovalStatus)
-                        .ToList();
+                    // splitting potential multiple statuses passed by the API
+                    var statuses = query.ContractApprovalStatus.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    // filtering contracts to only include those with specified status/es
+                    for (int i = 0; i < statuses.Length; i++)
+                    {
+                        var contractWithCurrentStatus = filteredQueryableAsset.AssetContracts
+                            .Where(c => c.ApprovalStatus == statuses[i])
+                            .ToList();
+                        filteredQueryableAsset.AssetContracts.Concat(contractWithCurrentStatus);
+                    }
                 }
                 return filteredQueryableAsset;
             })

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -110,10 +110,13 @@ namespace HousingSearchApi.V1.Gateways
             assetListResponse.Assets.AddRange(searchResponse.Documents.Select(queryableAsset =>
             {
                 var filteredQueryableAsset = queryableAsset.CreateAll();
-                // filtering contracts to only include those with specified status
-                filteredQueryableAsset.AssetContracts = filteredQueryableAsset.AssetContracts
-                    .Where(c => c.ApprovalStatus == query.ContractApprovalStatus)
-                    .ToList();
+                if (query.ContractApprovalStatus != null)
+                {
+                    // filtering contracts to only include those with specified status
+                    filteredQueryableAsset.AssetContracts = filteredQueryableAsset.AssetContracts
+                        .Where(c => c.ApprovalStatus == query.ContractApprovalStatus)
+                        .ToList();
+                }
                 return filteredQueryableAsset;
             })
             );

--- a/HousingSearchApi/V1/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V1/Gateways/SearchGateway.cs
@@ -113,7 +113,8 @@ namespace HousingSearchApi.V1.Gateways
                 if (query.ContractApprovalStatus != null)
                 {
                     // splitting potential multiple statuses passed by the API
-                    var statuses = query.ContractApprovalStatus.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    string space = "%20";
+                    var statuses = query.ContractApprovalStatus.Split(space, StringSplitOptions.RemoveEmptyEntries);
                     // filtering contracts to only include those with specified status/es
                     for (int i = 0; i < statuses.Length; i++)
                     {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-2040

## Describe this PR

### *What is the problem we're trying to solve*

When we moved from a single `AssetContract` to multiple `AssetContracts`, we inherited the ES querying logic that assumed there would be only one `AssetContract`.
This means that ES would return _all_ `AssetContracts` pertaining to an asset, even if some of those had a different `approvalStatus` than the ones passed in the query. This is because we are searching on the `assets` ES index, not the contracts one (which doesn't exist), and subquerying contracts in the preexisting query was not feasible. Our ES resultset is effectively our source of truth.

### *What changes have we introduced*

We had therefore to introduce further filtering on the Gateway, so that only contracts that have the specified status would be returned.
In addition to this, we also needed to handle a multiple status search (see code), which ES already contemplates and handles.

### *Follow up actions after merging PR*

We'll need to reintroduce "Approved" contracts in the listener as per [this PR ](https://github.com/LBHackney-IT/housing-search-listener/pull/160)as the API will now be able to handle this.

Also, we'll need to refactor and tidy up the code a bit (follow up ticket to come).