### PR TITLE
Add confidence score

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -58,7 +58,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -85,7 +85,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("assetAddress").GetProperty("postCode").GetString().Should().Be(searchTextPostcode);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -113,7 +113,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -141,7 +141,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("assetAddress").GetProperty("addressLine1").GetString().Should().Contain(searchText);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -175,7 +175,7 @@ public class AssetSearchTests : BaseSearchTests
             searchTerms.ForEach(term =>
                 firstResultAddress.Should().Contain(term)
             );
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -204,7 +204,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(randomAsset.GetProperty("id").GetString());
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
 
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -231,7 +231,7 @@ public class AssetSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("assets")[0];
         firstResult.GetProperty("tenure").GetProperty("paymentReference").GetString().Should().Be(searchText);
-        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+        firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
     }
 
     #endregion
@@ -256,7 +256,7 @@ public class AssetSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("assets")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+        firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
     }
 
     #endregion

--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -58,6 +58,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -84,6 +85,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("assetAddress").GetProperty("postCode").GetString().Should().Be(searchTextPostcode);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -111,6 +113,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -138,6 +141,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("assetAddress").GetProperty("addressLine1").GetString().Should().Contain(searchText);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -171,6 +175,7 @@ public class AssetSearchTests : BaseSearchTests
             searchTerms.ForEach(term =>
                 firstResultAddress.Should().Contain(term)
             );
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
     }
@@ -199,6 +204,7 @@ public class AssetSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("assets")[0];
             firstResult.GetProperty("id").GetString().Should().Be(randomAsset.GetProperty("id").GetString());
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
 
         });
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -225,6 +231,7 @@ public class AssetSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("assets")[0];
         firstResult.GetProperty("tenure").GetProperty("paymentReference").GetString().Should().Be(searchText);
+        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
     }
 
     #endregion
@@ -249,6 +256,7 @@ public class AssetSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("assets")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
     }
 
     #endregion

--- a/HousingSearchApi.Tests/V2/E2ETests/PersonSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/PersonSearchTests.cs
@@ -63,6 +63,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("tenures")[0].GetProperty("assetFullAddress").GetString().Should().Be(query);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -100,6 +101,7 @@ public class PersonSearchTests : BaseSearchTests
             {
                 return result.GetProperty("id").GetString() == expectedReturnedId;
             }).Should().BeTrue();
+            firstResults[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -134,6 +136,7 @@ public class PersonSearchTests : BaseSearchTests
             {
                 return result.GetProperty("id").GetString() == expectedReturnedId;
             }).Should().BeTrue();
+            firstResults[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -162,6 +165,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("tenures")[0].GetProperty("paymentReference").GetString().Trim().Should().Be(searchText.Trim());
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         }
         catch (AssertionException e)
         {
@@ -197,6 +201,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -228,6 +233,7 @@ public class PersonSearchTests : BaseSearchTests
             firstResults.Any(result =>
                 result.GetProperty("id").GetString() == expectedReturnedId
             ).Should().BeTrue();
+            root.GetProperty("results").GetProperty("persons")[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -266,6 +272,7 @@ public class PersonSearchTests : BaseSearchTests
                 {
                     return nameParts.All(part => result.GetProperty("firstname").GetString().Contains(part) || result.GetProperty("surname").GetString().Contains(part));
                 }).Should().BeTrue();
+            results[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);

--- a/HousingSearchApi.Tests/V2/E2ETests/PersonSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/PersonSearchTests.cs
@@ -63,7 +63,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("tenures")[0].GetProperty("assetFullAddress").GetString().Should().Be(query);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -101,7 +101,7 @@ public class PersonSearchTests : BaseSearchTests
             {
                 return result.GetProperty("id").GetString() == expectedReturnedId;
             }).Should().BeTrue();
-            firstResults[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResults[0].GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -136,7 +136,7 @@ public class PersonSearchTests : BaseSearchTests
             {
                 return result.GetProperty("id").GetString() == expectedReturnedId;
             }).Should().BeTrue();
-            firstResults[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResults[0].GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -165,7 +165,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("tenures")[0].GetProperty("paymentReference").GetString().Trim().Should().Be(searchText.Trim());
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         }
         catch (AssertionException e)
         {
@@ -201,7 +201,7 @@ public class PersonSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("persons")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -233,7 +233,7 @@ public class PersonSearchTests : BaseSearchTests
             firstResults.Any(result =>
                 result.GetProperty("id").GetString() == expectedReturnedId
             ).Should().BeTrue();
-            root.GetProperty("results").GetProperty("persons")[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            root.GetProperty("results").GetProperty("persons")[0].GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -272,7 +272,7 @@ public class PersonSearchTests : BaseSearchTests
                 {
                     return nameParts.All(part => result.GetProperty("firstname").GetString().Contains(part) || result.GetProperty("surname").GetString().Contains(part));
                 }).Should().BeTrue();
-            results[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            results[0].GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);

--- a/HousingSearchApi.Tests/V2/E2ETests/TenureSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/TenureSearchTests.cs
@@ -62,7 +62,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -96,7 +96,7 @@ public class TenureSearchTests : BaseSearchTests
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             var firstResultAddress = firstResult.GetProperty("tenuredAsset").GetProperty("fullAddress").GetString();
             firstResultAddress.Should().Contain(searchText);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -131,7 +131,7 @@ public class TenureSearchTests : BaseSearchTests
             var firstResultAddress = firstResult.GetProperty("tenuredAsset").GetProperty("fullAddress").GetString();
             // should contain each search term
             searchTerms.ForEach(term => firstResultAddress.Should().Contain(term));
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -159,7 +159,7 @@ public class TenureSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+        firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class TenureSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+        firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
     }
 
     # endregion
@@ -212,7 +212,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -247,7 +247,7 @@ public class TenureSearchTests : BaseSearchTests
             var results = root.GetProperty("results").GetProperty("tenures");
             var resultIds = results.EnumerateArray().Select(r => r.GetProperty("id").GetString()).ToList();
             resultIds.Should().Contain(expectedReturnedId);
-            results[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            results[0].GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -283,7 +283,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
-            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
+            firstResult.GetProperty("confidenceScore").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);

--- a/HousingSearchApi.Tests/V2/E2ETests/TenureSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/TenureSearchTests.cs
@@ -62,6 +62,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -95,6 +96,7 @@ public class TenureSearchTests : BaseSearchTests
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             var firstResultAddress = firstResult.GetProperty("tenuredAsset").GetProperty("fullAddress").GetString();
             firstResultAddress.Should().Contain(searchText);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -129,6 +131,7 @@ public class TenureSearchTests : BaseSearchTests
             var firstResultAddress = firstResult.GetProperty("tenuredAsset").GetProperty("fullAddress").GetString();
             // should contain each search term
             searchTerms.ForEach(term => firstResultAddress.Should().Contain(term));
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -156,6 +159,7 @@ public class TenureSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
     }
 
     [Fact]
@@ -176,6 +180,7 @@ public class TenureSearchTests : BaseSearchTests
         root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
         var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
         firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+        firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
     }
 
     # endregion
@@ -207,6 +212,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -241,6 +247,7 @@ public class TenureSearchTests : BaseSearchTests
             var results = root.GetProperty("results").GetProperty("tenures");
             var resultIds = results.EnumerateArray().Select(r => r.GetProperty("id").GetString()).ToList();
             resultIds.Should().Contain(expectedReturnedId);
+            results[0].GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);
@@ -276,6 +283,7 @@ public class TenureSearchTests : BaseSearchTests
             root.GetProperty("total").GetInt32().Should().BeGreaterThan(0);
             var firstResult = root.GetProperty("results").GetProperty("tenures")[0];
             firstResult.GetProperty("id").GetString().Should().Be(expectedReturnedId);
+            firstResult.GetProperty("score").GetDouble().Should().BeGreaterThan(0);
         });
 
         successCount.Should().BeGreaterThanOrEqualTo(minSuccessCount);

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -113,7 +113,6 @@ public class SearchGateway : ISearchGateway
             var doc = JsonSerializer.SerializeToElement(h.Source);
             var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(doc.GetRawText());
 
-            // Using the clearer name here
             dict["confidenceScore"] = h.Score ?? 0.0;
 
             return (object) dict;

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -6,7 +6,8 @@ using HousingSearchApi.V2.Domain.DTOs;
 using HousingSearchApi.V2.Gateways.Interfaces;
 using Nest;
 using Ops = HousingSearchApi.V2.Gateways.SearchOperations;
-using System.Text.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace HousingSearchApi.V2.Gateways;
 
@@ -110,12 +111,9 @@ public class SearchGateway : ISearchGateway
 
         var documents = searchResponse.Hits.Select(h =>
         {
-            var doc = JsonSerializer.SerializeToElement(h.Source);
-            var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(doc.GetRawText());
-
-            dict["confidenceScore"] = h.Score ?? 0.0;
-
-            return (object) dict;
+            var jObject = JObject.FromObject(h.Source);
+            jObject["confidenceScore"] = h.Score ?? 0.0;
+            return (object) jObject;
         }).ToList();
 
         return new SearchResponseDto

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -6,7 +6,6 @@ using HousingSearchApi.V2.Domain.DTOs;
 using HousingSearchApi.V2.Gateways.Interfaces;
 using Nest;
 using Ops = HousingSearchApi.V2.Gateways.SearchOperations;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace HousingSearchApi.V2.Gateways;

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -108,14 +108,15 @@ public class SearchGateway : ISearchGateway
         if (!searchResponse.IsValid)
             throw new Exception($"Elasticsearch search failed: {searchResponse.DebugInformation}");
 
-        var documents = searchResponse.Hits.Select(h => {
+        var documents = searchResponse.Hits.Select(h =>
+        {
             var doc = JsonSerializer.SerializeToElement(h.Source);
             var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(doc.GetRawText());
-            
+
             // Using the clearer name here
-            dict["confidenceScore"] = h.Score ?? 0.0; 
-            
-            return (object)dict;
+            dict["confidenceScore"] = h.Score ?? 0.0;
+
+            return (object) dict;
         }).ToList();
 
         return new SearchResponseDto

--- a/HousingSearchApi/V2/Gateways/SearchGateway.cs
+++ b/HousingSearchApi/V2/Gateways/SearchGateway.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using HousingSearchApi.V2.Domain.DTOs;
 using HousingSearchApi.V2.Gateways.Interfaces;
 using Nest;
 using Ops = HousingSearchApi.V2.Gateways.SearchOperations;
+using System.Text.Json;
 
 namespace HousingSearchApi.V2.Gateways;
 
@@ -106,9 +108,19 @@ public class SearchGateway : ISearchGateway
         if (!searchResponse.IsValid)
             throw new Exception($"Elasticsearch search failed: {searchResponse.DebugInformation}");
 
+        var documents = searchResponse.Hits.Select(h => {
+            var doc = JsonSerializer.SerializeToElement(h.Source);
+            var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(doc.GetRawText());
+            
+            // Using the clearer name here
+            dict["confidenceScore"] = h.Score ?? 0.0; 
+            
+            return (object)dict;
+        }).ToList();
+
         return new SearchResponseDto
         {
-            Documents = searchResponse.Documents,
+            Documents = documents,
             Total = searchResponse.HitsMetadata.Total.Value,
         };
     }

--- a/database/Makefile
+++ b/database/Makefile
@@ -18,6 +18,7 @@ INSTANCE_ID_PATH := " /platform-apis-jump-box-instance-name"
 ES_DOMAIN_PATH := " /housing-search-api/${ENVIRONMENT}/elasticsearch-domain"
 
 # -- Parameters --
+_ := $(shell aws sts get-caller-identity --profile ${PROFILE} > /dev/null 2>&1 || aws sso login --profile ${PROFILE})
 INSTANCE_ID := $(shell aws ssm get-parameter --name ${INSTANCE_ID_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
 ES_DOMAIN := $(shell aws ssm get-parameter --name ${ES_DOMAIN_PATH} --region "eu-west-2" --profile ${PROFILE} --query Parameter.Value --output text)
 ES_DOMAIN := $(shell echo ${ES_DOMAIN} | sed 's/https:\/\///g')
@@ -26,16 +27,6 @@ ES_PORT := 443
 DATABASE_PARAMS := '{"host":["${ES_DOMAIN}"], "portNumber":["${ES_PORT}"], "localPortNumber":["${LOCAL_PORT}"]}'
 
 # -- Commands --
-
-# Use this command to login to the AWS SSO service
-sso_login:
-	if (aws sts get-caller-identity --profile ${PROFILE})
-	then
-		echo "Session still valid"
-	else
-		echo "Session expired, logging in"
-		aws sso login --profile ${PROFILE}
-	fi
 
 port_forwarding_to_housing_search:
 	echo "Connecting to ${ES_DOMAIN_PATH} on local port ${LOCAL_PORT}\n\n==="


### PR DESCRIPTION
## Link to JIRA ticket

[Add a link to the JIRA ticket that the changes in this PR describe.](https://hackney.atlassian.net/jira/software/projects/HT/boards/428?jql=assignee%20%3D%20712020%3Aec561b5f-6107-4deb-a8e8-198d5103ad0e&selectedIssue=HT-835)

## Describe this PR

### *What is the problem we're trying to solve*

The current search results lack a confidence score.

### *What changes have we introduced*

This PR updates the search gateway to inject the Elasticsearch search score as a confidenceScore field into each result document across Assets, Persons, and Tenures. It also includes comprehensive E2E test updates to verify that the confidenceScore is correctly returned and populated for all search types.