### PR TITLE
Fix punctuation search issue

### DIFF
--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -260,5 +260,41 @@ public class AssetSearchTests : BaseSearchTests
     }
 
     #endregion
+
+    #region Special Characters
+
+    [Theory]
+    [InlineData("12/A", "*12\\/A*")]
+    [InlineData("Flat (A)", "*Flat* AND *\\(A\\)*")]
+    [InlineData("double  space", "*double* AND *space*")]
+    public void WildcardQueryStringQuery_EscapesAndSplitsCorrectly(string input, string expectedQuery)
+    {
+        // Arrange
+        Nest.Fields fields = new[] { "field1" };
+
+        // Act
+        var queryFunc = HousingSearchApi.V2.Gateways.SearchOperations.WildcardQueryStringQuery(input, fields);
+        var container = queryFunc(new Nest.QueryContainerDescriptor<object>());
+        var queryStringQuery = ((Nest.IQueryContainer) container).QueryString;
+
+        // Assert
+        queryStringQuery.Query.Should().Be(expectedQuery);
+    }
+
+    [Fact]
+    public async Task SearchAddress_WithSpecialCharacters_ReturnsOk()
+    {
+        // Arrange
+        var query = "12/A (Flat)";
+        var request = CreateSearchRequest(query);
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    #endregion
 }
 

--- a/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
+++ b/HousingSearchApi.Tests/V2/E2ETests/AssetSearchTests.cs
@@ -263,24 +263,6 @@ public class AssetSearchTests : BaseSearchTests
 
     #region Special Characters
 
-    [Theory]
-    [InlineData("12/A", "*12\\/A*")]
-    [InlineData("Flat (A)", "*Flat* AND *\\(A\\)*")]
-    [InlineData("double  space", "*double* AND *space*")]
-    public void WildcardQueryStringQuery_EscapesAndSplitsCorrectly(string input, string expectedQuery)
-    {
-        // Arrange
-        Nest.Fields fields = new[] { "field1" };
-
-        // Act
-        var queryFunc = HousingSearchApi.V2.Gateways.SearchOperations.WildcardQueryStringQuery(input, fields);
-        var container = queryFunc(new Nest.QueryContainerDescriptor<object>());
-        var queryStringQuery = ((Nest.IQueryContainer) container).QueryString;
-
-        // Assert
-        queryStringQuery.Query.Should().Be(expectedQuery);
-    }
-
     [Fact]
     public async Task SearchAddress_WithSpecialCharacters_ReturnsOk()
     {
@@ -297,4 +279,3 @@ public class AssetSearchTests : BaseSearchTests
 
     #endregion
 }
-

--- a/HousingSearchApi.Tests/V2/Gateways/SearchOperationsTests.cs
+++ b/HousingSearchApi.Tests/V2/Gateways/SearchOperationsTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using HousingSearchApi.V2.Gateways;
+using Nest;
+using System.Linq;
+using Xunit;
+
+namespace HousingSearchApi.Tests.V2.Gateways
+{
+    public class SearchOperationsTests
+    {
+        [Theory]
+        [InlineData("12/A", "*12\\/A*")]
+        [InlineData("Flat (A)", "*Flat* AND *\\(A\\)*")]
+        [InlineData("double  space", "*double* AND *space*")]
+        public void WildcardQueryStringQuery_EscapesAndSplitsCorrectly(string input, string expectedQuery)
+        {
+            // Arrange
+            Nest.Fields fields = new[] { "field1" };
+
+            // Act
+            var queryFunc = SearchOperations.WildcardQueryStringQuery(input, fields);
+            var container = queryFunc(new QueryContainerDescriptor<object>());
+            var queryStringQuery = ((IQueryContainer) container).QueryString;
+
+            // Assert
+            queryStringQuery.Query.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void WildcardMatch_HandlesMultipleSpacesCorrectly()
+        {
+            // Arrange
+            Nest.Fields fields = new[] { "field1" };
+            var input = "double  space";
+
+            // Act
+            var queryFunc = SearchOperations.WildcardMatch(input, fields, 1);
+            var container = queryFunc(new QueryContainerDescriptor<object>());
+            var boolQuery = ((IQueryContainer) container).Bool;
+
+            // Assert
+            boolQuery.Should.Count().Should().Be(2);
+        }
+    }
+}

--- a/HousingSearchApi/V2/Gateways/SearchOperations.cs
+++ b/HousingSearchApi/V2/Gateways/SearchOperations.cs
@@ -2,12 +2,21 @@ using Nest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 
 namespace HousingSearchApi.V2.Gateways;
 
 static class SearchOperations
 {
+    private static readonly Regex _esReservedChars = new Regex(@"([\\+\-\=\&\|!\(\)\{\}\[\]\^\""\~\*\?\:\/])");
+
+    private static string Escape(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        return _esReservedChars.Replace(text, @"\$1");
+    }
+
     public static Func<QueryContainerDescriptor<object>, QueryContainer>
         Nested(string path, Func<QueryContainerDescriptor<object>, QueryContainer> func)
     {
@@ -63,7 +72,7 @@ static class SearchOperations
         {
             if (string.IsNullOrEmpty(phrase))
                 return new List<string>();
-            return phrase.Split(' ').Select(word => $"*{word}*").ToList();
+            return phrase.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(word => $"*{word}*").ToList();
         }
 
         var listOfWildcardedWords = ProcessWildcards(searchText);
@@ -143,7 +152,8 @@ static class SearchOperations
     public static Func<QueryContainerDescriptor<object>, QueryContainer> WildcardQueryStringQuery(string searchText,
             Fields fields, double? boost = null)
     {
-        var queryString = string.Join(" AND ", searchText.Split(' ').Select(word => $"*{word}*"));
+        var escapedSearchText = Escape(searchText);
+        var queryString = string.Join(" AND ", escapedSearchText.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(word => $"*{word}*"));
         return should => should.QueryString(q => q
             .Query(queryString)
             .Fields(fields)


### PR DESCRIPTION
## Link to JIRA ticket

Add a link to the JIRA ticket that the changes in this PR describe.

## Describe this PR

### *What is the problem we're trying to solve*

Searches containing special characters (e.g., /, (, )) in addresses currently cause a 400 Bad Request crash. This occurs because Elasticsearch interprets these characters as syntax commands rather than literal text.

### *What changes have we introduced*

- Added a robust Escape method to SearchOperations.cs to sanitize all Elasticsearch reserved characters.

- Updated splitting logic to ignore multiple consecutive spaces, preventing the creation of invalid empty search terms.

- Added unit and E2E tests to AssetSearchTests.cs to verify that special characters no longer cause crashes and are handled as literal text.
